### PR TITLE
feat: AI-workload bottleneck classifier, GPU throttle detector, compact GPU menu-bar mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+AI-workload monitoring — the next-version hero feature.
+
+- **AI Workload view** — a bottleneck classifier with a single verdict:
+  bandwidth-bound / compute-bound / thermal-throttled / memory-pressured (plus idle /
+  GPU-active). Front-and-center hero card on the dashboard; mirrored as a `Workload:`
+  line in the menu bar.
+- **Per-chip memory-bandwidth ceiling table** + a "% of ceiling" gauge (M1–M4; Max bins
+  split by P-core count; self-corrects to the observed peak for chips outside the table).
+- **GPU throttle detector** — flags the GPU clock held below its slowly-decaying rolling
+  peak while thermal pressure has risen (warning banner + menu-bar flame).
+- **Compact GPU menu-bar mode** — single line: GPU% / GPU W / GPU GB/s / die °C.
+
 ## v1.0.2 — 2026-06-09
 
 Crash fix: launch failure on macOS 27.

--- a/README.md
+++ b/README.md
@@ -29,16 +29,20 @@ Prefer to build it yourself? See [Build & run](#build--run).
 
 ## Highlights
 
+- **AI Workload view** — a bottleneck classifier (*bandwidth-bound* / *compute-bound* /
+  *thermal-throttled* / *memory-pressured*) with a per-chip **"% of ceiling"** bandwidth
+  gauge — answers "what's limiting my local LLM right now?"
 - **E-core / P-core split** — per-cluster utilization + real DVFS frequency
 - **GPU** — utilization, power, frequency
 - **ANE & Media Engine** — Neural-Engine power and media-codec bandwidth (the differentiators)
 - **Memory bandwidth** — CPU / GPU / Media / total GB/s (the local-LLM bottleneck signal)
 - **Memory** — Wired / Active / Compressed / Free stacked bar + macOS **memory-pressure** alerts
 - **Network** ↑/↓ and **Disk** read/write + free space, with live graphs
-- **Temperatures** — grouped CPU / GPU / Memory / Battery (SMC), fan RPM, thermal pressure
+- **Temperatures** — grouped CPU / GPU / Memory / Battery (SMC), fan RPM, thermal pressure,
+  and **GPU throttle detection** (clock held below its rolling peak under pressure)
 - **Power** — per-domain CPU / GPU / ANE / DRAM / SoC, plus battery %
 - **Processes** — sort, filter, kill (in-card scroll)
-- **No `sudo` required.** Menu-bar mode **and** full dashboard.
+- **No `sudo` required.** Full dashboard **and** menu-bar mode (with a compact GPU readout).
 
 ## Build & run
 

--- a/Sources/KtopCore/Bottleneck.swift
+++ b/Sources/KtopCore/Bottleneck.swift
@@ -1,0 +1,109 @@
+//
+//  File:      Bottleneck.swift
+//  Created:   2026-06-12
+//  Updated:   2026-06-12
+//  Developer: Kennt Kim / Calida Lab
+//  Overview:  The AI-workload bottleneck classifier (hero feature). Given a snapshot,
+//             the unified-memory-bandwidth ceiling, and whether the GPU is throttling,
+//             it returns the single dominant bottleneck. Also holds the per-chip
+//             bandwidth ceiling table used for the "% of ceiling" gauge.
+//  Notes:     Pure value logic, no UI. Color mapping lives in the UI layer (Theme).
+//             Ceilings are theoretical unified-memory bandwidth (GB/s) from Apple's
+//             specs; callers should take max(ceiling, observedPeak) so the figure
+//             self-corrects upward if a chip exceeds the table.
+//
+import Foundation
+
+public enum Bottleneck: String, Sendable {
+    case idle               // GPU effectively idle
+    case gpuActive          // GPU busy, no single dominant limiter
+    case bandwidthBound     // memory BW near ceiling, GPU not maxed (LLM token generation)
+    case computeBound       // GPU saturated, BW has headroom (prompt processing)
+    case thermalThrottled   // thermal pressure + GPU clock held below its peak
+    case memoryPressured    // unified memory full (macOS pressure critical)
+
+    /// Short UI label.
+    public var label: String {
+        switch self {
+        case .idle:             return "Idle"
+        case .gpuActive:        return "GPU active"
+        case .bandwidthBound:   return "Bandwidth-bound"
+        case .computeBound:     return "Compute-bound"
+        case .thermalThrottled: return "Thermal-throttled"
+        case .memoryPressured:  return "Memory-pressured"
+        }
+    }
+
+    /// One-line explanation of what the verdict means for an AI workload.
+    public var detail: String {
+        switch self {
+        case .idle:             return "No significant GPU workload"
+        case .gpuActive:        return "GPU busy — no single bottleneck"
+        case .bandwidthBound:   return "Memory BW near ceiling, GPU not maxed — LLM token generation"
+        case .computeBound:     return "GPU saturated, bandwidth has headroom — prompt processing"
+        case .thermalThrottled: return "Clock held down by heat — sustained performance limited"
+        case .memoryPressured:  return "Unified memory full — swapping limits throughput"
+        }
+    }
+
+    /// Whether this verdict is a problem the user should act on (vs a neutral profile).
+    public var isProblem: Bool {
+        self == .thermalThrottled || self == .memoryPressured
+    }
+
+    // MARK: - Classification
+
+    /// Classifies the dominant bottleneck. `ceilingGBs` is the unified-memory bandwidth
+    /// ceiling; `throttling` is the GPU-clock-vs-peak throttle decision (UI-tracked).
+    /// Precedence: memory > thermal > (workload profile).
+    public static func classify(_ s: SystemSnapshot,
+                                ceilingGBs: Double,
+                                throttling: Bool) -> Bottleneck {
+        if s.memory.pressure == .critical { return .memoryPressured }
+        if throttling { return .thermalThrottled }
+        // Desktop compositing keeps a resting GPU around 10–25%; below this is "idle"
+        // for AI-workload purposes (no meaningful GPU compute).
+        if s.gpu.usage < 0.30 { return .idle }
+
+        let bwFraction = ceilingGBs > 0 ? s.bandwidth.totalGBs / ceilingGBs : 0
+        if bwFraction >= 0.75 && s.gpu.usage < 0.95 { return .bandwidthBound }
+        if s.gpu.usage >= 0.90 && bwFraction < 0.60 { return .computeBound }
+        return .gpuActive
+    }
+
+    // MARK: - Per-chip bandwidth ceiling table
+
+    /// Theoretical unified-memory bandwidth ceiling (GB/s) for an Apple Silicon SoC,
+    /// matched from the sysctl brand string (e.g. "Apple M3 Max"). Max-tier chips ship
+    /// in two memory bins; `pCoreCount` disambiguates (full vs binned). Returns 0 for an
+    /// unrecognized chip so the caller can fall back to the observed peak.
+    public static func bandwidthCeilingGBs(chipName: String, pCoreCount: Int) -> Double {
+        let n = chipName.lowercased()
+        func has(_ s: String) -> Bool { n.contains(s) }
+
+        if has("m1") {
+            if has("ultra") { return 800 }
+            if has("max")   { return 400 }
+            if has("pro")   { return 200 }
+            return 68
+        }
+        if has("m2") {
+            if has("ultra") { return 800 }
+            if has("max")   { return 400 }
+            if has("pro")   { return 200 }
+            return 100
+        }
+        if has("m3") {
+            if has("ultra") { return 800 }
+            if has("max")   { return pCoreCount >= 12 ? 400 : 300 }   // full vs binned
+            if has("pro")   { return 150 }
+            return 100
+        }
+        if has("m4") {
+            if has("max")   { return pCoreCount >= 12 ? 546 : 410 }   // full vs binned
+            if has("pro")   { return 273 }
+            return 120
+        }
+        return 0   // unknown → caller uses observed peak
+    }
+}

--- a/Sources/WhisPlayInfo/DashboardView.swift
+++ b/Sources/WhisPlayInfo/DashboardView.swift
@@ -1,13 +1,15 @@
 //
 //  File:      DashboardView.swift
 //  Created:   2026-06-08
-//  Updated:   2026-06-08
+//  Updated:   2026-06-12
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Full-window dashboard. Header (chip, cores, SoC power, battery), then
 //             CPU + GPU side by side, combined Memory|Bandwidth and Network|Disk cards
 //             (btop-style vertical split), a Sensors accordion, and the process table.
 //  Notes:     No separate Power/Thermal cards — power lives in the header, temperature
 //             in the Sensors card. Combined cards split left/right with a Divider.
+//             allWarnings() adds context-aware banners (bandwidth-bound, GPU throttle)
+//             on top of the snapshot's own data-level warnings.
 //
 import SwiftUI
 import KtopCore
@@ -23,6 +25,15 @@ struct DashboardView: View {
                 if !warnings.isEmpty { WarningBanner(warnings: warnings) }
 
                 HeaderView(topology: monitor.topology, power: snapshot.power, battery: snapshot.battery)
+
+                AIWorkloadCard(bottleneck: monitor.bottleneck,
+                               gpu: snapshot.gpu,
+                               bandwidth: snapshot.bandwidth,
+                               ceilingGBs: monitor.bandwidthCeilingGBs,
+                               chipName: monitor.topology?.chipName ?? "",
+                               engineHint: snapshot.likelyAIEngine,
+                               clockDropFraction: monitor.gpuClockDropFraction)
+                    .frame(height: 96)
 
                 HStack(spacing: 8) {
                     CPUCard(cpu: snapshot.cpu, topology: monitor.topology, history: monitor.history.pCPU)
@@ -55,10 +66,14 @@ struct DashboardView: View {
     }
 
     private func allWarnings(_ s: SystemSnapshot) -> [SystemSnapshot.Warning] {
+        // Bandwidth-bound is no longer a banner alert — it's the AI Workload verdict
+        // (AIWorkloadCard). The banner keeps only the data-level + throttle alarms.
         var warnings = s.warnings
-        if s.gpu.usage > 0.5 && s.bandwidth.totalGBs > 0.8 * monitor.bandwidthPeakGBs {
-            warnings.append(.init(level: .warning,
-                                  message: "Bandwidth-bound — LLM token throughput limited"))
+        if monitor.gpuThrottling {
+            let level: SystemSnapshot.Warning.Level = s.thermal.pressure == .critical ? .critical : .warning
+            warnings.append(.init(level: level,
+                                  message: String(format: "GPU throttling — clock %.0f MHz (-%.0f%% vs peak)",
+                                                   s.gpu.freqMHz, monitor.gpuClockDropFraction * 100)))
         }
         return warnings
     }
@@ -117,6 +132,61 @@ private struct WarningBanner: View {
                             in: RoundedRectangle(cornerRadius: 8))
                 .overlay(RoundedRectangle(cornerRadius: 8)
                     .strokeBorder((critical ? Color.red : Color.orange).opacity(0.4), lineWidth: 1))
+            }
+        }
+    }
+}
+
+// MARK: - AI Workload (hero)
+
+/// The hero card: the dominant bottleneck verdict plus a "% of ceiling" bandwidth gauge.
+/// "Where does the AI workload actually run, and what limits it right now?"
+private struct AIWorkloadCard: View {
+    let bottleneck: Bottleneck
+    let gpu: GPUSample
+    let bandwidth: BandwidthSample
+    let ceilingGBs: Double
+    let chipName: String
+    let engineHint: String
+    let clockDropFraction: Double
+
+    private var bwFraction: Double { ceilingGBs > 0 ? min(1, bandwidth.totalGBs / ceilingGBs) : 0 }
+    private var shortChip: String { chipName.replacingOccurrences(of: "Apple ", with: "") }
+
+    var body: some View {
+        Card(title: "AI Workload") {
+            VStack(alignment: .leading, spacing: 7) {
+                HStack(spacing: 8) {
+                    Circle().fill(bottleneck.color).frame(width: 9, height: 9)
+                    Text(bottleneck.label)
+                        .font(.system(size: 13, weight: .bold, design: .monospaced))
+                        .foregroundStyle(bottleneck.color)
+                    Text(bottleneck.detail)
+                        .font(.system(size: 10.5, design: .monospaced))
+                        .foregroundStyle(Theme.dim)
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                }
+                Bar(label: "Mem BW % of ceiling",
+                    value: bwFraction,
+                    detail: String(format: "%.0f%% · %.0f / %.0f GB/s · %@",
+                                   bwFraction * 100, bandwidth.totalGBs, ceilingGBs, shortChip))
+                HStack(spacing: 6) {
+                    Text(String(format: "GPU %.0f%%", gpu.usagePercent))
+                        .font(.system(size: 10.5, weight: .medium, design: .monospaced))
+                        .foregroundStyle(Theme.text)
+                    // Suppress the engine hint when idle — claiming "LLM-style" on an
+                    // idle GPU contradicts the verdict.
+                    if bottleneck != .idle {
+                        Text("·").font(.system(size: 10.5)).foregroundStyle(Theme.faint)
+                        Text(bottleneck == .thermalThrottled
+                             ? String(format: "GPU clock -%.0f%% vs peak", clockDropFraction * 100)
+                             : engineHint)
+                            .font(.system(size: 10.5, design: .monospaced))
+                            .foregroundStyle(Theme.dim)
+                    }
+                    Spacer(minLength: 0)
+                }
             }
         }
     }

--- a/Sources/WhisPlayInfo/KtopMonitor.swift
+++ b/Sources/WhisPlayInfo/KtopMonitor.swift
@@ -1,13 +1,15 @@
 //
 //  File:      KtopMonitor.swift
 //  Created:   2026-06-08
-//  Updated:   2026-06-08
+//  Updated:   2026-06-12
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Observable view-model that drives the UI. Polls SystemSampler on a
 //             background task ~once per second and publishes the latest snapshot plus
 //             a short SoC-power history for sparklines.
 //  Notes:     Sampling runs via Task.detached (off main); SystemSampler is
 //             @unchecked Sendable and only touched there. UI reads snapshot on main.
+//             gpuClockPeakMHz is a slowly-decaying rolling peak; gpuThrottling flags a
+//             GPU clock held below that peak while thermal pressure has risen.
 //
 import Foundation
 import Observation
@@ -57,11 +59,53 @@ final class KtopMonitor {
     private(set) var mediaPeakGBs: Double = 2
     private(set) var anePeakWatts: Double = 2
 
+    // Rolling peak GPU clock (MHz), basis for throttle detection. Decays slowly so a
+    // brief boost doesn't pin it forever, yet it outlasts a sustained throttle — unlike
+    // a short-window max, which would normalize the suppressed clock as the new peak.
+    private(set) var gpuClockPeakMHz: Double = 0
+    private static let gpuClockPeakDecay = 0.999
+
     private let sampler = SystemSampler()
     private var loopTask: Task<Void, Never>?
 
     init() {
         topology = sampler.topology
+    }
+
+    /// True when the GPU clock is held well below its rolling peak while the GPU is
+    /// active and thermal pressure has risen above nominal — i.e. thermal throttling.
+    /// The clock-drop guard distinguishes a real throttle from ordinary DVFS idle (a
+    /// low clock with no work), and the usage guard keeps an idle GPU from tripping it.
+    var gpuThrottling: Bool {
+        guard gpuClockPeakMHz > 0 else { return false }
+        return snapshot.gpu.usage > 0.3
+            && snapshot.thermal.pressure != .nominal
+            && snapshot.gpu.freqMHz < 0.85 * gpuClockPeakMHz
+    }
+
+    /// How far the current GPU clock sits below its rolling peak (0...1; 0 when at/above).
+    var gpuClockDropFraction: Double {
+        guard gpuClockPeakMHz > 0, snapshot.gpu.freqMHz < gpuClockPeakMHz else { return 0 }
+        return 1 - snapshot.gpu.freqMHz / gpuClockPeakMHz
+    }
+
+    /// Unified-memory bandwidth ceiling (GB/s). The per-chip spec value, raised to the
+    /// observed peak if traffic ever exceeds it (so the figure never under-reports and
+    /// still works on chips missing from the table).
+    var bandwidthCeilingGBs: Double {
+        let spec = topology.map { Bottleneck.bandwidthCeilingGBs(chipName: $0.chipName, pCoreCount: $0.pCoreCount) } ?? 0
+        return max(spec, bandwidthPeakGBs)
+    }
+
+    /// Current total unified-memory bandwidth as a fraction of the ceiling (0...1).
+    var bandwidthPercentOfCeiling: Double {
+        let ceiling = bandwidthCeilingGBs
+        return ceiling > 0 ? min(1, snapshot.bandwidth.totalGBs / ceiling) : 0
+    }
+
+    /// The single dominant AI-workload bottleneck right now (hero feature verdict).
+    var bottleneck: Bottleneck {
+        Bottleneck.classify(snapshot, ceilingGBs: bandwidthCeilingGBs, throttling: gpuThrottling)
     }
 
     func start() {
@@ -77,6 +121,7 @@ final class KtopMonitor {
                 self.bandwidthPeakGBs = max(self.bandwidthPeakGBs, snap.bandwidth.totalGBs)
                 self.mediaPeakGBs = max(self.mediaPeakGBs, snap.bandwidth.mediaGBs)
                 self.anePeakWatts = max(self.anePeakWatts, snap.power.aneWatts)
+                self.gpuClockPeakMHz = max(snap.gpu.freqMHz, self.gpuClockPeakMHz * Self.gpuClockPeakDecay)
                 self.history.push(snap)
                 let interval = UserDefaults.standard.object(forKey: "refreshInterval") as? Double ?? 1.0
                 try? await Task.sleep(for: .seconds(max(0.3, interval)))

--- a/Sources/WhisPlayInfo/MenuBarView.swift
+++ b/Sources/WhisPlayInfo/MenuBarView.swift
@@ -1,11 +1,13 @@
 //
 //  File:      MenuBarView.swift
 //  Created:   2026-06-08
-//  Updated:   2026-06-08
+//  Updated:   2026-06-12
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Compact menu-bar popover content: the essentials at a glance (E/P, mem,
 //             GPU, bandwidth, power, die temp) plus Quit.
 //  Notes:     Shares the same KtopMonitor as the full window, so both stay in sync.
+//             "compactGPUMode" (UserDefaults) swaps the full readout for a single
+//             GPU-focused line: GPU% / GPU W / GPU GB/s / die °C.
 //
 import SwiftUI
 import AppKit
@@ -14,31 +16,16 @@ import KtopCore
 struct MenuBarView: View {
     let monitor: KtopMonitor
     @AppStorage("temperatureFahrenheit") private var fahrenheit = false
+    @AppStorage("compactGPUMode") private var compactGPU = false
     @Environment(\.openSettings) private var openSettings
 
     var body: some View {
         let snapshot = monitor.snapshot
         VStack(alignment: .leading, spacing: 9) {
-            Text("WhisPlayInfo")
-                .font(.system(size: 13, weight: .bold, design: .monospaced))
-                .foregroundStyle(Theme.accent)
-
-            Bar(label: "E", value: snapshot.cpu.eUsage,
-                detail: String(format: "%.0f%%", snapshot.cpu.eUsagePercent))
-            Bar(label: "P", value: snapshot.cpu.pUsage,
-                detail: String(format: "%.0f%%", snapshot.cpu.pUsagePercent))
-            Bar(label: "MEM", value: snapshot.memory.usedFraction,
-                detail: String(format: "%.0f%%", snapshot.memory.usedPercent))
-
-            Divider()
-            KV(key: "GPU", value: String(format: "%.0f%% · %.1f W", snapshot.gpu.usagePercent, snapshot.power.gpuWatts))
-            KV(key: "ANE", value: String(format: "%.1f W", snapshot.power.aneWatts))
-            KV(key: "Media", value: String(format: "%.1f GB/s", snapshot.bandwidth.mediaGBs))
-            KV(key: "Mem BW", value: String(format: "%.0f GB/s", snapshot.bandwidth.totalGBs))
-            KV(key: "SoC power", value: String(format: "%.1f W", snapshot.power.socWatts))
-            KV(key: "CPU temp", value: formatTemperature(snapshot.temperature.cpuCelsius, fahrenheit: fahrenheit))
-            if snapshot.temperature.hasBattery {
-                KV(key: "Battery", value: formatTemperature(snapshot.temperature.batteryCelsius, fahrenheit: fahrenheit))
+            if compactGPU {
+                compactGPURow(snapshot)
+            } else {
+                fullReadout(snapshot)
             }
 
             Divider()
@@ -50,8 +37,70 @@ struct MenuBarView: View {
             .font(.system(size: 12))
         }
         .padding(14)
-        .frame(width: 270)
+        .frame(width: compactGPU ? 340 : 270)
         .background(Theme.bg)
         .foregroundStyle(Theme.text)
+    }
+
+    /// Single-line GPU-focused readout: GPU% / GPU W / GPU bandwidth / die °C.
+    @ViewBuilder
+    private func compactGPURow(_ s: SystemSnapshot) -> some View {
+        HStack(spacing: 8) {
+            Text("GPU")
+                .font(.system(size: 11, weight: .bold, design: .monospaced))
+                .foregroundStyle(Theme.accent)
+            compactValue(String(format: "%.0f%%", s.gpu.usagePercent), color: Theme.heat(s.gpu.usage))
+            compactSeparator
+            compactValue(String(format: "%.1f W", s.power.gpuWatts))
+            compactSeparator
+            compactValue(String(format: "%.0f GB/s", s.bandwidth.gpuGBs))
+            compactSeparator
+            compactValue(formatTemperature(s.temperature.cpuCelsius, fahrenheit: fahrenheit),
+                         color: monitor.gpuThrottling ? Theme.heat(1) : Theme.text)
+            if monitor.gpuThrottling {
+                Image(systemName: "flame.fill")
+                    .font(.system(size: 11))
+                    .foregroundStyle(Theme.heat(1))
+                    .help("GPU thermal throttling")
+            }
+        }
+    }
+
+    private func compactValue(_ text: String, color: Color = Theme.text) -> some View {
+        Text(text)
+            .font(.system(size: 12, weight: .medium, design: .monospaced))
+            .foregroundStyle(color)
+    }
+
+    private var compactSeparator: some View {
+        Text("·").font(.system(size: 12, design: .monospaced)).foregroundStyle(Theme.faint)
+    }
+
+    /// The standard multi-line readout (E/P, memory, GPU, ANE, bandwidth, power, temps).
+    @ViewBuilder
+    private func fullReadout(_ snapshot: SystemSnapshot) -> some View {
+        Text("WhisPlayInfo")
+            .font(.system(size: 13, weight: .bold, design: .monospaced))
+            .foregroundStyle(Theme.accent)
+
+        KV(key: "Workload", value: monitor.bottleneck.label, valueColor: monitor.bottleneck.color)
+
+        Bar(label: "E", value: snapshot.cpu.eUsage,
+            detail: String(format: "%.0f%%", snapshot.cpu.eUsagePercent))
+        Bar(label: "P", value: snapshot.cpu.pUsage,
+            detail: String(format: "%.0f%%", snapshot.cpu.pUsagePercent))
+        Bar(label: "MEM", value: snapshot.memory.usedFraction,
+            detail: String(format: "%.0f%%", snapshot.memory.usedPercent))
+
+        Divider()
+        KV(key: "GPU", value: String(format: "%.0f%% · %.1f W", snapshot.gpu.usagePercent, snapshot.power.gpuWatts))
+        KV(key: "ANE", value: String(format: "%.1f W", snapshot.power.aneWatts))
+        KV(key: "Media", value: String(format: "%.1f GB/s", snapshot.bandwidth.mediaGBs))
+        KV(key: "Mem BW", value: String(format: "%.0f GB/s", snapshot.bandwidth.totalGBs))
+        KV(key: "SoC power", value: String(format: "%.1f W", snapshot.power.socWatts))
+        KV(key: "CPU temp", value: formatTemperature(snapshot.temperature.cpuCelsius, fahrenheit: fahrenheit))
+        if snapshot.temperature.hasBattery {
+            KV(key: "Battery", value: formatTemperature(snapshot.temperature.batteryCelsius, fahrenheit: fahrenheit))
+        }
     }
 }

--- a/Sources/WhisPlayInfo/SettingsView.swift
+++ b/Sources/WhisPlayInfo/SettingsView.swift
@@ -1,19 +1,21 @@
 //
 //  File:      SettingsView.swift
 //  Created:   2026-06-08
-//  Updated:   2026-06-08
+//  Updated:   2026-06-12
 //  Developer: Kennt Kim / Calida Lab
-//  Overview:  Preferences window (Cmd+,). Refresh cadence and temperature unit,
-//             persisted in UserDefaults via @AppStorage.
-//  Notes:     Keys: "refreshInterval" (seconds), "temperatureFahrenheit" (Bool).
-//             KtopMonitor reads refreshInterval each loop; temperature views read the
-//             unit. Both update live without restart.
+//  Overview:  Preferences window (Cmd+,). Refresh cadence, temperature unit, and the
+//             menu-bar compact GPU mode, persisted in UserDefaults via @AppStorage.
+//  Notes:     Keys: "refreshInterval" (seconds), "temperatureFahrenheit" (Bool),
+//             "compactGPUMode" (Bool). KtopMonitor reads refreshInterval each loop;
+//             temperature views read the unit; MenuBarView reads compactGPUMode. All
+//             update live without restart.
 //
 import SwiftUI
 
 struct SettingsView: View {
     @AppStorage("refreshInterval") private var refreshInterval = 1.0
     @AppStorage("temperatureFahrenheit") private var fahrenheit = false
+    @AppStorage("compactGPUMode") private var compactGPU = false
 
     var body: some View {
         Form {
@@ -27,8 +29,9 @@ struct SettingsView: View {
                 Text("Celsius (°C)").tag(false)
                 Text("Fahrenheit (°F)").tag(true)
             }
+            Toggle("Compact GPU mode (menu bar)", isOn: $compactGPU)
         }
         .formStyle(.grouped)
-        .frame(width: 380, height: 160)
+        .frame(width: 380, height: 200)
     }
 }

--- a/Sources/WhisPlayInfo/Theme.swift
+++ b/Sources/WhisPlayInfo/Theme.swift
@@ -1,16 +1,18 @@
 //
 //  File:      Theme.swift
 //  Created:   2026-06-08
-//  Updated:   2026-06-08
+//  Updated:   2026-06-12
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Shared visual language and reusable UI atoms (Card, Bar, KV, Sparkline).
 //             Restrained instrument-panel look: one accent, muted heat colors, dense
 //             monospaced typography. All in-app text is English.
 //  Notes:     Theme.heat(fraction) maps 0...1 load to green/amber/red. Cards are
 //             neutral (no per-card colors) so data — not chrome — carries the eye.
+//             Bottleneck.color lives here (UI layer) so KtopCore stays SwiftUI-free.
 //
 import SwiftUI
 import Charts
+import KtopCore
 
 enum Theme {
     static let bg     = Color(red: 0.051, green: 0.055, blue: 0.067)
@@ -26,6 +28,21 @@ enum Theme {
         case ..<0.55: return Color(red: 0.34, green: 0.74, blue: 0.49)
         case ..<0.82: return Color(red: 0.87, green: 0.66, blue: 0.28)
         default:      return Color(red: 0.88, green: 0.37, blue: 0.37)
+        }
+    }
+}
+
+extension Bottleneck {
+    /// UI accent for each verdict: neutral when fine, amber/green for the workload
+    /// profiles, red for the two problem states. Kept out of KtopCore (no SwiftUI there).
+    var color: Color {
+        switch self {
+        case .idle:             return Theme.faint
+        case .gpuActive:        return Theme.accent
+        case .computeBound:     return Theme.heat(0.4)   // GPU well-utilized — healthy
+        case .bandwidthBound:   return Theme.heat(0.7)   // a known limiter, expected
+        case .thermalThrottled: return Theme.heat(1)
+        case .memoryPressured:  return Theme.heat(1)
         }
     }
 }

--- a/docs/NEXT_VERSION.md
+++ b/docs/NEXT_VERSION.md
@@ -4,14 +4,21 @@ v1.0.0 is a general Apple Silicon monitor. The next version specializes toward
 **AI-inference monitoring** on Apple Silicon — the niche neither terminal monitors
 nor Activity Monitor cover.
 
+## Shipped (post-v1.0.2, on `main`)
+
+- **AI Workload view (hero)** — a bottleneck classifier with a single verdict:
+  *bandwidth-bound* / *compute-bound* / *thermal-throttled* / *memory-pressured*
+  (plus *idle* / *GPU-active*). Front-and-center hero card on the dashboard, mirrored
+  as a `Workload:` line in the menu bar. Precedence: memory > thermal > workload profile.
+- **Per-chip memory-bandwidth ceiling table** + a **"% of ceiling" gauge**
+  (M1–M4; Max bins disambiguated by P-core count; self-corrects up to the observed peak
+  for chips outside the table).
+- **GPU throttle detector** — flags the GPU clock held below its slowly-decaying rolling
+  peak while thermal pressure has risen above nominal (banner + menu-bar flame).
+- **Compact GPU menu-bar mode** — single line: `GPU% / GPU W / GPU GB/s / die °C`.
+
 ## Planned
 
-- **AI Workload view (hero)** — a bottleneck classifier:
-  - *Bandwidth-bound* (memory BW near ceiling, GPU not maxed) — typical LLM token generation
-  - *Compute-bound* (GPU ~100%, BW has headroom) — prompt processing
-  - *Thermal-throttled* (pressure + frequency drop)
-  - *Memory-pressured* (macOS pressure red)
-- **Per-chip memory-bandwidth ceiling table** → a "% of ceiling" gauge (M1/Pro/Max/Ultra, M2–M4)
 - **AI runtime detection** — recognize `ollama`, `llama.cpp`, `MLX`, `LM Studio`, etc. and surface them
 - **Engine attribution** — GPU/Metal vs ANE, as a clear hint
 - **Model memory budget** — estimate the largest model that fits in free unified memory

--- a/docs/display-spec.md
+++ b/docs/display-spec.md
@@ -44,7 +44,7 @@ Tracing today's growing workloads makes the differentiator clear:
 | Processes (top/tree/kill) | ✓✓ | ✗ | top apps | ✓ |
 | Disk / Network | ✓ | ✗ | ✓✓ | ✓ |
 | Battery | basic | ✗ | ✓✓ | ✓ |
-| Alerts | ✗ | ✗ | ✓ | ✓ (memory pressure, bandwidth-bound) |
+| Alerts | ✗ | ✗ | ✓ | ✓✓ (bottleneck classifier, GPU throttle, memory pressure) |
 
 **Read:** NeoAsitop = strong chip metrics (plain UI) / iStat = broad (weak on AI; no ANE/bandwidth) / btop = strong processes & UX (thin on Apple Silicon).
 → **WhisPlayInfo = NeoAsitop's chip metrics + iStat's memory-pressure/thermal breadth + btop's process/UX**, plus an AI-workload lens.
@@ -89,24 +89,29 @@ All data sources are sudoless (see `ioreport-channels.md`).
 
 ---
 
-## 3. "AI Workload" view (roadmap — see NEXT_VERSION.md)
+## 3. "AI Workload" view (shipped)
 
-A dedicated, curated panel that answers "why is my AI workload slow?" at a glance:
+A curated hero card that answers "where does my AI workload run, and what limits it
+right now?" at a glance. A single **bottleneck classifier** verdict drives it:
 
 ```
-┌─ AI Workload ──────────────────────────────┐
-│ GPU    ███████████░  88%   24.3 W           │
-│ ANE    ░░░░░░░░░░░░   2%  (est.)  idle       │
-│ Mem BW ██████████░░  142 / 160 GB/s         │
-│ Mem    wired 38.2 GB · pressure ●elevated   │
-│ Power  package 41 W                          │
-│ Thermal ● nominal (no throttle)             │
-│ ─ Likely engine: GPU/Metal (LLM-style)  ─   │
-└─────────────────────────────────────────────┘
+┌─ AI Workload ─────────────────────────────────────────────────┐
+│ ● Bandwidth-bound   Memory BW near ceiling, GPU not maxed      │
+│ Mem BW % of ceiling ████████░░ 78% · 312 / 400 GB/s · M3 Max   │
+│ GPU 64% · GPU/Metal (LLM-style)                                │
+└────────────────────────────────────────────────────────────────┘
 ```
 
-- "Likely engine": GPU high / ANE low → `GPU/Metal (LLM-style)`; ANE high → `ANE (CoreML-style)`.
-- Bandwidth near the chip ceiling → a `Bandwidth-bound` warning (LLM token-generation bottleneck).
+- **Verdict** (precedence: memory > thermal > workload profile):
+  - *Memory-pressured* — unified memory full (macOS pressure critical).
+  - *Thermal-throttled* — GPU clock held below its rolling peak while pressure rises.
+  - *Bandwidth-bound* — BW near the chip ceiling, GPU not maxed (LLM token generation).
+  - *Compute-bound* — GPU saturated, BW has headroom (prompt processing).
+  - *GPU-active* / *Idle* — otherwise.
+- **"% of ceiling"** uses a per-chip unified-memory-bandwidth table (M1–M4, Max bins
+  split by P-core count), raised to the observed peak so it self-corrects and still
+  works on chips not in the table.
+- **Likely engine**: GPU high / ANE low → `GPU/Metal (LLM-style)`; ANE high → `ANE (CoreML-style)`.
 
 This interpretation layer — not the raw numbers — is what sets WhisPlayInfo apart from
 general-purpose monitors.


### PR DESCRIPTION
## What

Implements the **AI Workload view** hero feature from `docs/NEXT_VERSION.md`, plus
two supporting GPU-focused surfaces.

### AI Workload bottleneck classifier (the hero)
A single verdict — "where does the AI workload run, and what limits it right now?":
- **Bandwidth-bound** — memory BW near ceiling, GPU not maxed (LLM token generation)
- **Compute-bound** — GPU saturated, BW has headroom (prompt processing)
- **Thermal-throttled** — GPU clock held below its rolling peak while pressure rises
- **Memory-pressured** — unified memory full (macOS pressure critical)
- (plus *idle* / *GPU-active*)

Precedence: memory > thermal > workload profile. Front-and-center hero card on the
dashboard; mirrored as a `Workload:` line in the menu bar.

### Per-chip bandwidth ceiling + "% of ceiling" gauge
Per-chip unified-memory-bandwidth table (M1–M4; Max bins split by P-core count).
Ceiling = `max(spec, observed peak)`, so it self-corrects and works on unlisted chips.

### GPU throttle detector
Flags the GPU clock held below its slowly-decaying rolling peak while thermal pressure
has risen above nominal — warning banner + menu-bar flame.

### Compact GPU menu-bar mode
Settings toggle for a single line: `GPU% / GPU W / GPU GB/s / die °C`.

## Design notes
- Classifier + ceiling table live in **KtopCore** as pure value logic (no SwiftUI);
  color mapping stays in the UI layer (`Theme`), per the repo's layer-separation rule.
- Fully sudoless; no new data sources — reuses existing IOReport GPU/bandwidth +
  ProcessInfo thermal samples.

## Testing
- `xcrun swift build` clean; `ktop-cli` verified on **M3 Max** (sudoless).
- On device: ceiling resolves M3 Max → 400 GB/s; idle verdict + gauge render correctly.
  Throttle / bandwidth verdicts need a sustained GPU load to exercise.

## Docs
README highlights, CHANGELOG (Unreleased), `display-spec.md` (AI Workload view → shipped
+ alerts row), `NEXT_VERSION.md` (hero items → Shipped).
