### PR TITLE
fix(menubar): unify action buttons across popovers

### DIFF
--- a/Sources/SiliconScope/MenuBarMetric.swift
+++ b/Sources/SiliconScope/MenuBarMetric.swift
@@ -1,7 +1,7 @@
 //
 //  File:      MenuBarMetric.swift
 //  Created:   2026-06-19
-//  Updated:   2026-06-19
+//  Updated:   2026-06-21
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  iStat-style per-metric menu-bar items. Each dashboard card can be toggled
 //             into its own menu-bar item (a stacked label + a mini histogram or two-line
@@ -386,9 +386,7 @@ struct CPUMenuDropdown: View {
                 }
             }
             Divider()
-            Button { openMainDashboard() } label: {
-                Label("Open Dashboard", systemImage: "macwindow").frame(maxWidth: .infinity)
-            }
+            OpenDashboardButton()
         }
         .padding(12).frame(width: 260).background(Theme.bg).foregroundStyle(Theme.text)
     }
@@ -437,11 +435,14 @@ struct MenuBarPin: View {
     }
 }
 
+/// The single primary action shared by every per-metric dropdown — styled to match the
+/// combined popover's Open Dashboard button.
 struct OpenDashboardButton: View {
     var body: some View {
         Button { openMainDashboard() } label: {
-            Label("Open Dashboard", systemImage: "macwindow").frame(maxWidth: .infinity)
+            Label("Open Dashboard", systemImage: "macwindow")
         }
+        .buttonStyle(PopoverButtonStyle(prominent: true))
     }
 }
 

--- a/Sources/SiliconScope/MenuBarView.swift
+++ b/Sources/SiliconScope/MenuBarView.swift
@@ -1,7 +1,7 @@
 //
 //  File:      MenuBarView.swift
 //  Created:   2026-06-08
-//  Updated:   2026-06-16
+//  Updated:   2026-06-21
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Compact menu-bar popover content: the essentials at a glance (E/P, mem,
 //             GPU, bandwidth, power, die temp), trend sparklines, top processes, plus
@@ -32,22 +32,26 @@ struct MenuBarView: View {
             }
 
             Divider()
-            Button {
-                openWindow(id: "siliconscope-main")
-                NSApplication.shared.activate(ignoringOtherApps: true)
-            } label: {
-                Label("Open Dashboard", systemImage: "macwindow")
-                    .frame(maxWidth: .infinity)
-            }
-            HStack {
-                Button("Settings…") { openSettings() }
-                if UpdaterController.shared.canCheck {
-                    Button("Check for Updates…") { UpdaterController.shared.checkForUpdates() }
+                .padding(.bottom, 2)
+            // One full-width primary action, then two equal-width secondary buttons — all
+            // share PopoverButtonStyle so they match the cards (panel fill, hairline border,
+            // mono label) at a uniform height. "Check for Updates…" lives in Settings.
+            VStack(spacing: 7) {
+                Button {
+                    openWindow(id: "siliconscope-main")
+                    NSApplication.shared.activate(ignoringOtherApps: true)
+                } label: {
+                    Label("Open Dashboard", systemImage: "macwindow")
                 }
-                Spacer()
-                Button("Quit") { NSApplication.shared.terminate(nil) }
+                .buttonStyle(PopoverButtonStyle(prominent: true))
+
+                HStack(spacing: 7) {
+                    Button("Settings") { openSettings() }
+                        .buttonStyle(PopoverButtonStyle())
+                    Button("Quit") { NSApplication.shared.terminate(nil) }
+                        .buttonStyle(PopoverButtonStyle())
+                }
             }
-            .font(.system(size: 12))
         }
         .padding(14)
         .frame(width: compactGPU ? 340 : 270)

--- a/Sources/SiliconScope/Theme.swift
+++ b/Sources/SiliconScope/Theme.swift
@@ -1,9 +1,10 @@
 //
 //  File:      Theme.swift
 //  Created:   2026-06-08
-//  Updated:   2026-06-12
+//  Updated:   2026-06-21
 //  Developer: Kennt Kim / Calida Lab
-//  Overview:  Shared visual language and reusable UI atoms (Card, Bar, KV, Sparkline).
+//  Overview:  Shared visual language and reusable UI atoms (Card, Bar, KV, Sparkline,
+//             PopoverButtonStyle).
 //             Restrained instrument-panel look: one accent, muted heat colors, dense
 //             monospaced typography. All in-app text is English.
 //  Notes:     Theme.heat(fraction) maps 0...1 load to green/amber/red. Cards are
@@ -238,6 +239,51 @@ struct Sparkline: View {
             chart.chartYScale(domain: yDomain)
         } else {
             chart
+        }
+    }
+}
+
+/// Popover footer button styled to match the cards: rounded panel fill, hairline border,
+/// monospaced label, uniform 28pt height, with hover + press feedback. `prominent` adds a
+/// subtle accent tint + outline for the single primary action (Open Dashboard); the others
+/// stay neutral so the hierarchy reads at a glance. Shared by the combined popover and each
+/// per-metric dropdown so every menu-bar surface uses the same buttons.
+struct PopoverButtonStyle: ButtonStyle {
+    var prominent = false
+
+    func makeBody(configuration: Configuration) -> some View {
+        StyleBody(configuration: configuration, prominent: prominent)
+    }
+
+    private struct StyleBody: View {
+        let configuration: Configuration
+        let prominent: Bool
+        @State private var hovering = false
+
+        var body: some View {
+            let pressed = configuration.isPressed
+            configuration.label
+                .font(.system(size: 12, weight: .medium, design: .monospaced))
+                .foregroundStyle(Theme.text)
+                .frame(maxWidth: .infinity)
+                .frame(height: 28)
+                .background(fill(pressed: pressed), in: RoundedRectangle(cornerRadius: 7))
+                .overlay(RoundedRectangle(cornerRadius: 7).strokeBorder(stroke, lineWidth: 1))
+                .contentShape(RoundedRectangle(cornerRadius: 7))
+                .onHover { hovering = $0 }
+                .animation(.easeOut(duration: 0.12), value: hovering)
+                .animation(.easeOut(duration: 0.12), value: pressed)
+        }
+
+        private func fill(pressed: Bool) -> Color {
+            if prominent {
+                return Theme.accent.opacity(pressed ? 0.34 : hovering ? 0.26 : 0.18)
+            }
+            return Color.white.opacity(pressed ? 0.14 : hovering ? 0.10 : 0.05)
+        }
+
+        private var stroke: Color {
+            prominent ? Theme.accent.opacity(0.55) : Theme.border
         }
     }
 }

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -2,10 +2,12 @@
 #
 #  File:      build-app.sh
 #  Created:   2026-06-12
-#  Updated:   2026-06-14
+#  Updated:   2026-06-21
 #  Overview:  Builds a local SiliconScope.app bundle from the SwiftPM executable.
 #  Notes:     This is for development/local install. It does not notarize or create
 #             a DMG; use scripts/package.sh for Developer ID distribution.
+#             Embeds Sparkle.framework (ad-hoc signed) so the bundle actually launches —
+#             the SPM binary links @rpath/Sparkle.framework.
 #
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -56,7 +58,24 @@ cat > "$APPDIR/Contents/Info.plist" <<PLIST
 </plist>
 PLIST
 
+echo "Embedding Sparkle.framework..."
+mkdir -p "$APPDIR/Contents/Frameworks"
+cp -R "$BIN_DIR/Sparkle.framework" "$APPDIR/Contents/Frameworks/"
+# The SPM binary links @rpath/Sparkle.framework; point rpath at the bundle's Frameworks.
+install_name_tool -add_rpath "@executable_path/../Frameworks" "$APPDIR/Contents/MacOS/$APP" 2>/dev/null || true
+
 echo "Ad-hoc signing..."
+# Sparkle: sign nested helpers (deep -> shallow), then the framework, then the app last.
+SPARKLE_FW="$APPDIR/Contents/Frameworks/Sparkle.framework"
+SPV="$SPARKLE_FW/Versions/$(ls "$SPARKLE_FW/Versions" | grep -v Current | head -1)"
+for nested in \
+  "$SPV/XPCServices/Installer.xpc" \
+  "$SPV/XPCServices/Downloader.xpc" \
+  "$SPV/Autoupdate" \
+  "$SPV/Updater.app"; do
+  [ -e "$nested" ] && codesign --force --sign - --timestamp=none "$nested"
+done
+codesign --force --sign - --timestamp=none "$SPARKLE_FW"
 codesign --force --sign - --timestamp=none "$APPDIR"
 codesign --verify --strict --verbose=2 "$APPDIR"
 


### PR DESCRIPTION
## What changed

### Menu-bar popover buttons

The combined popover and the per-metric popovers (CPU, GPU, Memory, Network, Disk, Sensors, Battery) used default system buttons that clashed with the dark monospaced card UI: uneven heights, a truncated `Check for Updates…` label, and a bulky full-width `Open Dashboard` sitting next to small bordered buttons.

A shared `PopoverButtonStyle` in `Theme.swift` now gives every button the card look: rounded panel fill, hairline border, monospaced label, fixed 28pt height, and hover + press feedback. A `prominent` variant adds an accent tint for the single primary action.

- **Combined popover** (`MenuBarView.swift`): `Open Dashboard` is the primary button; `Settings` and `Quit` split a row below at equal width. Dropped `Check for Updates…` from the popover since it already lives in Settings under *Startup & alerts*. Renamed `Settings…` to `Settings`.
- **Per-metric popovers** (`MenuBarMetric.swift`): the shared `OpenDashboardButton` adopts `PopoverButtonStyle(prominent: true)`. The CPU dropdown dropped its inline button copy and reuses `OpenDashboardButton` like the others.

### Dev build script

`scripts/build-app.sh` produced a bundle that crashed on launch:

```
dyld: Library not loaded: @rpath/Sparkle.framework
```

The SPM binary links Sparkle, but the script never embedded the framework. It now copies `Sparkle.framework` into `Contents/Frameworks/`, adds the `@executable_path/../Frameworks` rpath, and ad-hoc signs the nested helpers, matching what `scripts/package.sh` already does for Developer ID distribution.

## Testing

- `swift build` is clean.
- Built `dist/SiliconScope.app` via `scripts/build-app.sh` and launched it.
- Opened the combined popover and the CPU per-metric popover; both render the new buttons. The remaining per-metric popovers share the same `OpenDashboardButton` component.

## Screenshots

<!-- before / after -->

| Before | After |
| --- | --- |
| <img width="270" height="431" alt="image" src="https://github.com/user-attachments/assets/599103a0-9050-4a78-8066-8edc4d6dd772" /> | <img width="270" height="431" alt="image" src="https://github.com/user-attachments/assets/2ffe3f24-c1d9-4409-8a51-0c90e5f2f40a" /> |
| <img width="286" height="410" alt="image" src="https://github.com/user-attachments/assets/aff9e6e8-e491-4792-82d6-781c14154d1f" /> | <img width="286" height="410" alt="CleanShot 2026-06-21 at 13 42 41@2x" src="https://github.com/user-attachments/assets/0b498454-a18a-4a11-8fe9-5bfeaf79eb58" /> |
