### PR TITLE
fix(menubar): focus the Settings window when opened from the popover

### DIFF
--- a/Sources/SiliconScope/MenuBarView.swift
+++ b/Sources/SiliconScope/MenuBarView.swift
@@ -40,7 +40,13 @@ struct MenuBarView: View {
                     .frame(maxWidth: .infinity)
             }
             HStack {
-                Button("Settings…") { openSettings() }
+                Button("Settings…") {
+                    openSettings()
+                    // Bring the app forward so the Settings window opens in front of (and
+                    // focused over) whatever app the user clicked from — otherwise it appears
+                    // behind, inactive (grey), until a Cmd+Tab. Mirrors "Open Dashboard".
+                    NSApplication.shared.activate(ignoringOtherApps: true)
+                }
                 if UpdaterController.shared.canCheck {
                     Button("Check for Updates…") { UpdaterController.shared.checkForUpdates() }
                 }


### PR DESCRIPTION
## The bug

With the app running in the menu bar and another app focused (e.g. a browser), clicking `Settings…` in the popover opened the Settings window **behind** the front app. The window also rendered inactive (grey controls), and clicking inside it did not focus it. Only a `Cmd+Tab` to SiliconScope brought it forward.

## Cause

The `Settings…` button called only `openSettings()`. A menu-bar app that is not the frontmost app stays in the background, so the new window opens behind the active app and never becomes key.

## Fix

Activate the app right after `openSettings()`, the same thing the `Open Dashboard` button already does:

```swift
Button("Settings…") {
    openSettings()
    NSApplication.shared.activate(ignoringOtherApps: true)
}
```

One file changed (`Sources/SiliconScope/MenuBarView.swift`).

## Testing

Built and ran from `main` with the fix. With Finder focused, opened the popover and clicked `Settings…`: SiliconScope comes to the front and the Settings window opens focused (active controls), no `Cmd+Tab` needed.
