### PR TITLE
feat: add support for oMLX inference server

### DIFF
--- a/Sources/SiliconScope/SettingsView.swift
+++ b/Sources/SiliconScope/SettingsView.swift
@@ -21,6 +21,8 @@ struct SettingsView: View {
     @AppStorage("aiRuntimeAPIEnabled") private var aiRuntimeAPIEnabled = false
     @AppStorage("aiRuntimeOllamaPort") private var ollamaPort = 11434
     @AppStorage("aiRuntimeLMStudioPort") private var lmStudioPort = 1234
+    @AppStorage("aiRuntimeOmlxPort") private var omlxPort = 8000
+    @AppStorage("aiRuntimeOmlxApiKey") private var omlxApiKey = ""
     @AppStorage("notificationsEnabled") private var notificationsEnabled = false
     @AppStorage("showWarningBanner") private var showWarningBanner = true
     // Per-metric menu-bar items — same keys the ⬚ pin on each dashboard card writes, so the
@@ -94,6 +96,8 @@ struct SettingsView: View {
                 if aiRuntimeAPIEnabled {
                     TextField("Ollama port", value: $ollamaPort, format: .number.grouping(.never))
                     TextField("LM Studio port", value: $lmStudioPort, format: .number.grouping(.never))
+                    TextField("oMLX port", value: $omlxPort, format: .number.grouping(.never))
+                    TextField("oMLX API Key (optional)", text: $omlxApiKey)
                 }
             } header: {
                 Text("Local AI runtime API (opt-in)")
@@ -102,7 +106,7 @@ struct SettingsView: View {
             }
         }
         .formStyle(.grouped)
-        .frame(width: 400, height: aiRuntimeAPIEnabled ? 720 : 650)
+        .frame(width: 400, height: aiRuntimeAPIEnabled ? 760 : 650)
         .onAppear { autoUpdate = UpdaterController.shared.automaticallyChecks }
     }
 }

--- a/Sources/SiliconScope/SiliconScopeMonitor.swift
+++ b/Sources/SiliconScope/SiliconScopeMonitor.swift
@@ -216,6 +216,8 @@ final class SiliconScopeMonitor {
         let ollamaEmbedded: Int?
         let ollamaPort: Int
         let lmStudioPort: Int
+        let omlxPort: Int
+        let omlxApiKey: String
     }
 
     /// Captured under a brief main-actor hold, so the poll task doesn't retain the monitor
@@ -224,7 +226,9 @@ final class SiliconScopeMonitor {
         ProbeInputs(kind: snapshot.aiRuntime.primaryKind,
                     ollamaEmbedded: snapshot.aiRuntime.ollamaEmbeddedPort,
                     ollamaPort: Self.port(forKey: "aiRuntimeOllamaPort", default: 11434),
-                    lmStudioPort: Self.port(forKey: "aiRuntimeLMStudioPort", default: 1234))
+                    lmStudioPort: Self.port(forKey: "aiRuntimeLMStudioPort", default: 1234),
+                    omlxPort: Self.port(forKey: "aiRuntimeOmlxPort", default: 8000),
+                    omlxApiKey: UserDefaults.standard.string(forKey: "aiRuntimeOmlxApiKey") ?? "")
     }
 
     private func startAPIPollingIfNeeded() {
@@ -236,7 +240,9 @@ final class SiliconScopeMonitor {
                 let result = await client.probe(primaryKind: inputs.kind,
                                                 ollamaEmbeddedPort: inputs.ollamaEmbedded,
                                                 ollamaPort: inputs.ollamaPort,
-                                                lmStudioPort: inputs.lmStudioPort)
+                                                lmStudioPort: inputs.lmStudioPort,
+                                                omlxPort: inputs.omlxPort,
+                                                omlxApiKey: inputs.omlxApiKey)
                 self?.runtimeAPI = result
                 try? await Task.sleep(for: .seconds(Self.apiCadenceSeconds))
             }
@@ -289,7 +295,8 @@ final class SiliconScopeMonitor {
         }
         // 256 tokens keeps the decode running long enough that the ~1s power snapshots
         // capture steady-state draw (a 128-token run can finish before power ramps).
-        let result = await BenchmarkClient().run(kind: kind, port: port, model: model, numPredict: 256)
+        let apiKey = kind == .omlx ? (UserDefaults.standard.string(forKey: "aiRuntimeOmlxApiKey") ?? "") : nil
+        let result = await BenchmarkClient().run(kind: kind, port: port, model: model, apiKey: apiKey, numPredict: 256)
         box.done = true
         powerProbe.cancel()
 
@@ -318,6 +325,7 @@ final class SiliconScopeMonitor {
         case .lmStudio: return Self.port(forKey: "aiRuntimeLMStudioPort", default: 1234)
         case .rapidMLX: return 8000
         case .exo:      return 52415
+        case .omlx:     return Self.port(forKey: "aiRuntimeOmlxPort", default: 8000)
         case .llamaCpp: return snapshot.aiRuntime.ollamaEmbeddedPort ?? 8080
         default:        return Self.port(forKey: "aiRuntimeOllamaPort", default: 11434)
         }

--- a/Sources/SiliconScope/Theme.swift
+++ b/Sources/SiliconScope/Theme.swift
@@ -58,7 +58,7 @@ extension AIRuntimeKind {
         case .mlx:      return "cpu.fill"
         case .rapidMLX: return "hare.fill"
         case .exo:      return "point.3.connected.trianglepath.dotted"   // distributed cluster
-        case .jan, .gpt4all, .vllm: return "brain"
+        case .jan, .gpt4all, .vllm, .omlx: return "brain"
         }
     }
     var color: Color { Theme.accent }

--- a/Sources/SiliconScopeCore/AIRuntime.swift
+++ b/Sources/SiliconScopeCore/AIRuntime.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 public enum AIRuntimeKind: String, Sendable, CaseIterable, Codable {
-    case ollama, llamaCpp, lmStudio, mlx, rapidMLX, jan, gpt4all, vllm, exo
+    case ollama, llamaCpp, lmStudio, mlx, rapidMLX, jan, gpt4all, vllm, exo, omlx
 
     public var displayName: String {
         switch self {
@@ -28,6 +28,7 @@ public enum AIRuntimeKind: String, Sendable, CaseIterable, Codable {
         case .gpt4all:  return "GPT4All"
         case .vllm:     return "vLLM"
         case .exo:      return "exo"
+        case .omlx:     return "oMLX"
         }
     }
 
@@ -43,6 +44,7 @@ public enum AIRuntimeKind: String, Sendable, CaseIterable, Codable {
         if p.contains("/LM Studio.app/") { return .lmStudio }
         if p.contains("/Jan.app/") || p.contains("/jan/") { return .jan }
         if p.contains("/GPT4All.app/") || p.contains("/gpt4all/") { return .gpt4all }
+        if p.contains("/oMLX.app/") || p.contains("/omlx.app/") { return .omlx }
 
         // Stage 2 — basename / args (only reached when Stage 1 found nothing).
         let base = (p as NSString).lastPathComponent
@@ -60,6 +62,7 @@ public enum AIRuntimeKind: String, Sendable, CaseIterable, Codable {
         // names (hexo, Plexos, nexo) can't false-positive on the short "exo" substring.
         if base == "exo" || p.contains("/exo/main.py")
             || a.contains("/exo/main.py") || a.contains("/bin/exo") || a.contains(" exo.main") { return .exo }
+        if base == "omlx" || base == "oMLX" || base == "omlx-server" || base == "oMLX-server" { return .omlx }
 
         return nil
     }

--- a/Sources/SiliconScopeCore/Benchmark.swift
+++ b/Sources/SiliconScopeCore/Benchmark.swift
@@ -74,10 +74,10 @@ public struct BenchmarkClient: Sendable {
     private static let prompt = "Write three concise sentences explaining why the sky is blue."
 
     /// Runs one bounded generation and returns the decode rate, or nil on any failure.
-    public func run(kind: AIRuntimeKind, port: Int, model: String, numPredict: Int = 128) async -> BenchmarkResult? {
+    public func run(kind: AIRuntimeKind, port: Int, model: String, apiKey: String? = nil, numPredict: Int = 128) async -> BenchmarkResult? {
         switch kind {
         case .ollama: return await runOllama(port: port, model: model, numPredict: numPredict)
-        default:      return await runOpenAI(port: port, model: model, numPredict: numPredict)
+        default:      return await runOpenAI(port: port, model: model, apiKey: apiKey, numPredict: numPredict)
         }
     }
 
@@ -104,14 +104,14 @@ public struct BenchmarkClient: Sendable {
 
     // OpenAI-compatible (LM Studio, llama.cpp server): no pure decode timing, so time the
     // wall clock of a non-streamed completion and divide by completion_tokens.
-    private func runOpenAI(port: Int, model: String, numPredict: Int) async -> BenchmarkResult? {
+    private func runOpenAI(port: Int, model: String, apiKey: String?, numPredict: Int) async -> BenchmarkResult? {
         let body: [String: Any] = [
             "model": model,
             "messages": [["role": "user", "content": Self.prompt]],
             "max_tokens": numPredict, "temperature": 0, "stream": false,
         ]
         let start = Date()
-        guard let data = try? await post(port: port, path: "/v1/chat/completions", body: body) else { return nil }
+        guard let data = try? await post(port: port, path: "/v1/chat/completions", body: body, apiKey: apiKey) else { return nil }
         let elapsed = -start.timeIntervalSinceNow
         guard let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
               let usage = obj["usage"] as? [String: Any],
@@ -120,11 +120,14 @@ public struct BenchmarkClient: Sendable {
         return BenchmarkResult(tokensPerSec: Double(completion) / elapsed, tokenCount: completion)
     }
 
-    private func post(port: Int, path: String, body: [String: Any]) async throws -> Data {
+    private func post(port: Int, path: String, body: [String: Any], apiKey: String? = nil) async throws -> Data {
         guard let url = URL(string: "http://127.0.0.1:\(port)\(path)") else { throw LocalHTTP.HTTPError.badURL }
         var req = URLRequest(url: url)
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let apiKey = apiKey, !apiKey.isEmpty {
+            req.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
         req.httpBody = try JSONSerialization.data(withJSONObject: body)
         let (data, resp) = try await session.data(for: req)
         let code = (resp as? HTTPURLResponse)?.statusCode ?? -1

--- a/Sources/SiliconScopeCore/LocalHTTP.swift
+++ b/Sources/SiliconScopeCore/LocalHTTP.swift
@@ -27,11 +27,14 @@ public struct LocalHTTP: Sendable {
     }
 
     /// GET http://127.0.0.1:<port><path>. Returns the body on 2xx; throws otherwise.
-    public func get(port: Int, path: String) async throws -> Data {
+    public func get(port: Int, path: String, headers: [String: String] = [:]) async throws -> Data {
         guard let url = URL(string: "http://127.0.0.1:\(port)\(path)") else { throw HTTPError.badURL }
         return try await withLocalTimeout(seconds: 1.2) {
             var req = URLRequest(url: url)
             req.httpMethod = "GET"
+            for (k, v) in headers {
+                req.setValue(v, forHTTPHeaderField: k)
+            }
             let (data, resp) = try await session.data(for: req)
             let code = (resp as? HTTPURLResponse)?.statusCode ?? -1
             guard (200..<300).contains(code) else { throw HTTPError.badStatus(code) }

--- a/Sources/SiliconScopeCore/ProcessSampler.swift
+++ b/Sources/SiliconScopeCore/ProcessSampler.swift
@@ -92,7 +92,7 @@ public final class ProcessSampler {
         var pids = [pid_t](repeating: 0, count: Int(count) + 64)
         let byteCount = proc_listallpids(&pids, Int32(pids.count) * Int32(MemoryLayout<pid_t>.size))
         guard byteCount > 0 else { return [] }
-        let actual = Int(byteCount) / MemoryLayout<pid_t>.size
+        let actual = Int(byteCount)
         return Array(pids.prefix(actual))
     }
 

--- a/Sources/SiliconScopeCore/RuntimeAPIClient.swift
+++ b/Sources/SiliconScopeCore/RuntimeAPIClient.swift
@@ -20,13 +20,14 @@ public struct RuntimeAPIClient: Sendable {
 
     /// Probes the runtime that feature ① identified as primary.
     public func probe(primaryKind: AIRuntimeKind?, ollamaEmbeddedPort: Int?,
-                      ollamaPort: Int, lmStudioPort: Int) async -> RuntimeAPISample {
+                      ollamaPort: Int, lmStudioPort: Int, omlxPort: Int, omlxApiKey: String) async -> RuntimeAPISample {
         switch primaryKind {
         case .ollama:   return await probeOllama(port: ollamaPort)
         case .lmStudio: return await probeLMStudio(port: lmStudioPort)
         case .llamaCpp: return await probeLlamaCpp(port: ollamaEmbeddedPort ?? 8080)
-        case .rapidMLX: return await probeOpenAI(port: 8000, source: .rapidMLX)   // OpenAI-compatible
-        case .exo:      return await probeOpenAI(port: 52415, source: .exo)       // OpenAI-compatible cluster
+        case .rapidMLX: return await probeOpenAI(port: 8000, apiKey: nil, source: .rapidMLX)   // OpenAI-compatible
+        case .exo:      return await probeOpenAI(port: 52415, apiKey: nil, source: .exo)       // OpenAI-compatible cluster
+        case .omlx:     return await probeOpenAI(port: omlxPort, apiKey: omlxApiKey, source: .omlx)
         case .some:                                   // mlx / jan / gpt4all / vllm
             var s = RuntimeAPISample(); s.status = .runningNoServer; return s
         case .none:
@@ -91,9 +92,13 @@ public struct RuntimeAPIClient: Sendable {
 
     // MARK: - Generic OpenAI-compatible server (Rapid-MLX :8000, etc.)
 
-    private func probeOpenAI(port: Int, source: RuntimeAPISample.Source) async -> RuntimeAPISample {
+    private func probeOpenAI(port: Int, apiKey: String?, source: RuntimeAPISample.Source) async -> RuntimeAPISample {
         var s = RuntimeAPISample(); s.source = source
-        if let data = try? await http.get(port: port, path: "/v1/models"),
+        var headers: [String: String] = [:]
+        if let apiKey = apiKey, !apiKey.isEmpty {
+            headers["Authorization"] = "Bearer \(apiKey)"
+        }
+        if let data = try? await http.get(port: port, path: "/v1/models", headers: headers),
            let resp = try? JSONDecoder().decode(OpenAIModels.self, from: data) {
             s.status = .ok; s.lastUpdated = Date()
             s.loadedModels = (resp.data ?? []).map {

--- a/Sources/SiliconScopeCore/RuntimeAPISample.swift
+++ b/Sources/SiliconScopeCore/RuntimeAPISample.swift
@@ -46,7 +46,7 @@ public struct RuntimeModelInfo: Sendable, Equatable, Identifiable, Codable {
 }
 
 public struct RuntimeAPISample: Sendable, Equatable, Codable {
-    public enum Source: String, Sendable, Equatable, Codable { case ollama, llamaCpp, lmStudio, rapidMLX, exo }
+    public enum Source: String, Sendable, Equatable, Codable { case ollama, llamaCpp, lmStudio, rapidMLX, exo, omlx }
     public enum Status: String, Sendable, Equatable, Codable {
         case disabled            // feature off
         case unreachable         // no runtime / port closed / decode failure / stale (C4)

--- a/Sources/sscope-cli/main.swift
+++ b/Sources/sscope-cli/main.swift
@@ -77,7 +77,6 @@ print("\ntop processes by CPU (no sudo):")
 for p in allRows.prefix(8) {
     print(String(format: "  %6d  %6.1f%%  %8.1f MB   %@", p.pid, p.cpuPercent, p.memoryMB, p.name))
 }
-
 let ai = AIRuntimeSampler().sample(from: allRows)
 print("\nAI runtimes detected: \(ai.isActive ? "" : "none")")
 for p in ai.processes {
@@ -94,7 +93,7 @@ if let kind = ai.primaryKind {
 if CommandLine.arguments.contains("--ai") {
     let result = await RuntimeAPIClient().probe(
         primaryKind: ai.primaryKind, ollamaEmbeddedPort: ai.ollamaEmbeddedPort,
-        ollamaPort: 11434, lmStudioPort: 1234)
+        ollamaPort: 11434, lmStudioPort: 1234, omlxPort: 8000, omlxApiKey: "")
     let src = result.source.map { " · \($0.rawValue)" } ?? ""
     print("\nruntime API: \(result.status.rawValue)\(src)")
     for m in result.loadedModels {
@@ -114,11 +113,11 @@ if CommandLine.arguments.contains("--bench") {
     let kind = ai.primaryKind
     let api = await RuntimeAPIClient().probe(
         primaryKind: kind, ollamaEmbeddedPort: ai.ollamaEmbeddedPort,
-        ollamaPort: 11434, lmStudioPort: 1234)
+        ollamaPort: 11434, lmStudioPort: 1234, omlxPort: 8000, omlxApiKey: "")
     if let kind, let model = api.loadedModels.first?.name {
-        let port = switch kind { case .lmStudio: 1234; case .rapidMLX: 8000; case .exo: 52415; default: 11434 }
+        let port = switch kind { case .lmStudio: 1234; case .rapidMLX: 8000; case .exo: 52415; case .omlx: 8000; default: 11434 }
         print("\nbenchmark: \(kind.displayName) · \(model) — generating…")
-        if let r = await BenchmarkClient().run(kind: kind, port: port, model: model) {
+        if let r = await BenchmarkClient().run(kind: kind, port: port, model: model, apiKey: nil) {
             print(String(format: "  decode: %.1f tok/s  (%d tokens)", r.tokensPerSec, r.tokenCount))
             if let p = r.promptTokensPerSec { print(String(format: "  prefill: %.0f tok/s", p)) }
         } else {

--- a/Tests/SiliconScopeCoreTests/AIRuntimeMatchTests.swift
+++ b/Tests/SiliconScopeCoreTests/AIRuntimeMatchTests.swift
@@ -84,6 +84,15 @@ final class AIRuntimeMatchTests: XCTestCase {
                                               name: "rapid-mlx", args: nil), .mlx)
     }
 
+    func testOMLXMatch() {
+        XCTAssertEqual(AIRuntimeKind.match(path: "/Applications/oMLX.app/Contents/MacOS/oMLX", name: "oMLX", args: nil), .omlx)
+        XCTAssertEqual(AIRuntimeKind.match(path: "/Applications/omlx.app/Contents/MacOS/omlx", name: "omlx", args: nil), .omlx)
+        XCTAssertEqual(AIRuntimeKind.match(path: "/opt/homebrew/bin/omlx", name: "omlx", args: nil), .omlx)
+        XCTAssertEqual(AIRuntimeKind.match(path: "/opt/homebrew/bin/oMLX", name: "oMLX", args: nil), .omlx)
+        XCTAssertEqual(AIRuntimeKind.match(path: "/opt/homebrew/bin/omlx-server", name: "omlx-server", args: nil), .omlx)
+        XCTAssertEqual(AIRuntimeKind.match(path: "/opt/homebrew/bin/oMLX-server", name: "oMLX-server", args: nil), .omlx)
+    }
+
     // exo (exo-explore/exo) — OpenAI-compatible cluster server on :52415. Matches its console
     // entry point / module file / source path across the three ways it's launched.
     func testExoMatch() {


### PR DESCRIPTION
### Summary
This PR adds support for detecting, probing, and configuring the native Apple Silicon **oMLX** inference server, including support for local API key authentication. It also resolves a critical process-truncation bug in `ProcessSampler`.

### Fixes
- **Process Truncation Bug**: `ProcessSampler` was dividing the PID count returned by `proc_listallpids` by `4`, truncating the process table. This has been resolved.

### Features Added
- **Detection**: Matches GUI paths (`oMLX.app`, `omlx.app`) and CLI basenames (`omlx`, `omlx-server`).
- **Authorization**: Widens the `RuntimeAPIClient.probe` interface and `LocalHTTP` utilities to support optional Bearer API key headers.
- **Settings UI**: Adds user-configurable oMLX port and API Key fields.
- **Theme**: Maps the `.omlx` case to the `brain` SF Symbol.
- **Tests**: Adds the new unit test `testOMLXMatch()` (all 87 tests compile and pass).