### PR TITLE
fix(runtime): a jan/gpt4all username in the path is not an AI runtime

### DIFF
--- a/Sources/SiliconScopeCore/AIRuntime.swift
+++ b/Sources/SiliconScopeCore/AIRuntime.swift
@@ -1,7 +1,7 @@
 //
 //  File:      AIRuntime.swift
 //  Created:   2026-06-14
-//  Updated:   2026-07-02
+//  Updated:   2026-08-07
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Catalog + identity for local AI runtimes (Ollama, llama.cpp, LM Studio,
 //             MLX, Rapid-MLX, Jan, GPT4All, vLLM, exo). Pure logic — no syscalls; consumes
@@ -75,8 +75,8 @@ public enum AIRuntimeKind: String, Sendable, CaseIterable, Codable {
         // Stage 1 — bundle / well-known-dir identity (authoritative).
         if p.contains("/Ollama.app/") || p.contains("/.ollama/") || a.contains("/.ollama/") { return .ollama }
         if p.contains("/LM Studio.app/") { return .lmStudio }
-        if p.contains("/Jan.app/") || p.contains("/jan/") { return .jan }
-        if p.contains("/GPT4All.app/") || p.contains("/gpt4all/") { return .gpt4all }
+        if p.contains("/Jan.app/") { return .jan }
+        if p.contains("/GPT4All.app/") { return .gpt4all }
         if p.contains("/oMLX.app/") || p.contains("/omlx.app/") { return .omlx }
         // Calida Lab's own on-device AI apps. Bundle identity only — their executables are plain
         // names ("Spectalo", "SpectaLing") that a basename rule could collide with, and both ship

--- a/Tests/SiliconScopeCoreTests/AIRuntimeMatchTests.swift
+++ b/Tests/SiliconScopeCoreTests/AIRuntimeMatchTests.swift
@@ -1,7 +1,7 @@
 //
 //  File:      AIRuntimeMatchTests.swift
 //  Created:   2026-06-14
-//  Updated:   2026-07-02
+//  Updated:   2026-08-07
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Adversarial tests for AIRuntimeKind.match — the bundle-first, two-stage
 //             classifier. Locks in the cases that must NOT regress (Ollama runner is not
@@ -114,6 +114,23 @@ final class AIRuntimeMatchTests: XCTestCase {
                                          name: "hexo", args: "node /opt/homebrew/bin/hexo generate"))
         XCTAssertNil(AIRuntimeKind.match(path: "/Users/x/Plexos/bin/plexos", name: "plexos", args: nil))
         XCTAssertNil(AIRuntimeKind.match(path: "/usr/local/bin/nexo", name: "nexo", args: "nexo serve"))
+    }
+
+    // A `jan`/`gpt4all` SEGMENT in the path (a username like /Users/jan, or a same-named folder)
+    // must NOT be treated as the Jan/GPT4All runtime — only bundle identity (/Jan.app/, /GPT4All.app/)
+    // is authoritative. The bare-substring halves of these rules matched usernames and folders; this
+    // locks that false positive out. Mirrors testExoDoesNotFalsePositive.
+    func testJanGpt4allDoNotFalsePositive() {
+        // A `jan` username is not the Jan app.
+        XCTAssertNil(AIRuntimeKind.match(path: "/Users/jan/projects/foo", name: "foo", args: nil))
+        XCTAssertNil(AIRuntimeKind.match(path: "/Users/jan/.cache/pip/bin/pip", name: "pip", args: nil))
+        // A `gpt4all` folder is not the GPT4All app.
+        XCTAssertNil(AIRuntimeKind.match(path: "/Users/someone/gpt4all/notes", name: "vim", args: nil))
+        // Bundle identity still resolves positively.
+        XCTAssertEqual(AIRuntimeKind.match(path: "/Applications/Jan.app/Contents/MacOS/Jan",
+                                           name: "Jan", args: nil), .jan)
+        XCTAssertEqual(AIRuntimeKind.match(path: "/Applications/GPT4All.app/Contents/MacOS/gpt4all",
+                                           name: "gpt4all", args: nil), .gpt4all)
     }
 
     // primaryKind ranks by grouped RSS; the Ollama group (parent+runner) outweighs a small llama.cpp.


### PR DESCRIPTION
## Summary

`AIRuntimeKind.match` Stage 1 treated the bare substrings `/jan/` and `/gpt4all/` anywhere in the executable path as proof of the Jan / GPT4All runtimes. Those substrings also match a **username** (`/Users/jan/…`) or a same-named folder (`/Users/someone/gpt4all/notes`), so any process launched from such a home directory was silently classified as the wrong AI runtime. The bare halves were never a correct signal: on macOS both Jan and GPT4All ship as `.app` bundles only (`/Applications/Jan.app/`, `/Applications/GPT4All.app/`), and `~/.jan/` (the models dir) is dotted and lives in `args`, never as a bare `/jan/` segment of the executable path. There is no Homebrew/CLI/pip install path that would produce a non-bundle executable, so dropping the bare substrings loses no legitimate detection (unlike Ollama/LM Studio, which keep their `/.ollama/` and `base == "lms"` fallbacks).

## Fix

Removed the bare `/jan/` and `/gpt4all/` alternatives from the two Stage-1 rules in `Sources/SiliconScopeCore/AIRuntime.swift`; kept the authoritative **bundle identity** (`/Jan.app/`, `/GPT4All.app/`) only. No other runtime rule, no `displayName`, no enum change, no new deps, Core-only (no `SwiftUI`).

## Test plan

Mirrors the existing `testExoDoesNotFalsePositive`, which locks the same class of bug (short substring false-positive) for `exo`.

- [x] `xcrun swift build` -> `Build complete!` (exit 0)
- [x] `xcrun swift test` -> **168 tests, 0 failures** (baseline 167, +1 = the new `testJanGpt4allDoNotFalsePositive`)
- [x] `xcrun swift test --filter AIRuntimeMatchTests.testJanGpt4allDoNotFalsePositive` -> passed
- [x] Red proven: with the bare substrings temporarily restored, the new test fails on exactly the three `XCTAssertNil` cases (`/Users/jan/...`, `/Users/jan/.cache/...`, `/Users/someone/gpt4all/...`); restored -> green
- [x] `git diff --name-only main...HEAD` -> exactly `Sources/SiliconScopeCore/AIRuntime.swift` + `Tests/SiliconScopeCoreTests/AIRuntimeMatchTests.swift`
