### PR TITLE
fix(volume): clamp the used fraction so sparse/network volumes never read negative

### DIFF
--- a/Sources/SiliconScopeCore/VolumeSampler.swift
+++ b/Sources/SiliconScopeCore/VolumeSampler.swift
@@ -1,7 +1,7 @@
 //
 //  File:      VolumeSampler.swift
 //  Created:   2026-06-19
-//  Updated:   2026-06-19
+//  Updated:   2026-08-07
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Enumerates mounted volumes (local + network) with capacity/free, sudolessly
 //             via FileManager resource values. Powers the SSD/Disk menu-bar dropdown's
@@ -19,7 +19,7 @@ public struct VolumeInfo: Sendable, Identifiable, Equatable {
     public let isLocal: Bool
     public var id: String { name }
     public var usedFraction: Double {
-        totalBytes > 0 ? Double(totalBytes - freeBytes) / Double(totalBytes) : 0
+        totalBytes > 0 ? Double(totalBytes - min(max(freeBytes, 0), totalBytes)) / Double(totalBytes) : 0
     }
 }
 

--- a/Tests/SiliconScopeCoreTests/VolumeSamplerTests.swift
+++ b/Tests/SiliconScopeCoreTests/VolumeSamplerTests.swift
@@ -1,0 +1,39 @@
+//
+//  File:      VolumeSamplerTests.swift
+//  Created:   2026-08-07
+//  Updated:   2026-08-07
+//  Developer: Kennt Kim / Calida Lab
+//  Overview:  Unit tests for VolumeInfo.usedFraction, pinning the [0, 1] clamp so a sparse
+//             or network volume that reports freeBytes > totalBytes (or a negative freeBytes)
+//             can never make the used fraction read negative or above 1.0.
+//  Notes:     VolumeInfo.freeBytes is Int64 (unlike the UInt64 Disk path), so it can go negative;
+//             the clamp therefore needs max(…, 0) in addition to min(…, totalBytes). Values here
+//             are exact integer-rational Doubles, so plain XCTAssertEqual needs no accuracy.
+//
+import XCTest
+@testable import SiliconScopeCore
+
+final class VolumeSamplerTests: XCTestCase {
+
+    func testFreeAboveTotalClampsToZero() {
+        // Sparse/network volumes can report more free than total → used fraction must be 0, not -0.5.
+        let v = VolumeInfo(name: "X", totalBytes: 1_000_000, freeBytes: 1_500_000, isLocal: false)
+        XCTAssertEqual(v.usedFraction, 0.0)
+    }
+
+    func testNegativeFreeClampsToOne() {
+        // A negative Int64 freeBytes must read as fully used (1.0), not 1.2.
+        let v = VolumeInfo(name: "Y", totalBytes: 1_000_000, freeBytes: -200_000, isLocal: true)
+        XCTAssertEqual(v.usedFraction, 1.0)
+    }
+
+    func testNormalInRangeUnchanged() {
+        let v = VolumeInfo(name: "Z", totalBytes: 1_000_000, freeBytes: 250_000, isLocal: true)
+        XCTAssertEqual(v.usedFraction, 0.75)
+    }
+
+    func testZeroTotalGuardUnchanged() {
+        let v = VolumeInfo(name: "empty", totalBytes: 0, freeBytes: 0, isLocal: true)
+        XCTAssertEqual(v.usedFraction, 0.0)
+    }
+}


### PR DESCRIPTION
## Summary

`VolumeInfo.usedFraction` subtracted `freeBytes` directly, so on sparse disk images or some network/APFS volumes that report `freeBytes > totalBytes` (or a negative `freeBytes`), the used fraction read **negative** or **above 1.0**: a bogus bar in the SSD/Disk dropdown. Clamp `freeBytes` into `[0, totalBytes]` before subtracting.

## Fix

`Sources/SiliconScopeCore/VolumeSampler.swift`:

```diff
     public var usedFraction: Double {
-        totalBytes > 0 ? Double(totalBytes - freeBytes) / Double(totalBytes) : 0
+        totalBytes > 0 ? Double(totalBytes - min(max(freeBytes, 0), totalBytes)) / Double(totalBytes) : 0
     }
```

- `min(…, totalBytes)` brings parity with the sibling `DiskSample.usedFraction` (`Disk.swift`), which already guards the high end.
- `max(…, 0)` is **added here only** because `VolumeInfo.freeBytes` is `Int64` (can be negative), whereas `DiskSample.freeBytes` is `UInt64` (cannot). `Disk` is unchanged: already correct.

## Test plan

- [x] `xcrun swift build` -> `Build complete!` (exit 0)
- [x] `xcrun swift test` -> **171 tests, 0 failures** (baseline 167, +4 new)
- [x] New `Tests/SiliconScopeCoreTests/VolumeSamplerTests.swift` covers: `free > total` -> `0.0`; negative `free` -> `1.0`; normal in-range -> `0.75`; zero-total guard -> `0.0`
- [x] `git diff --name-only main...HEAD` -> exactly `Sources/SiliconScopeCore/VolumeSampler.swift` + the new test
