### PR TITLE
fix(runtime): a vllm username in the path is not the vLLM runtime

### DIFF
--- a/Sources/SiliconScopeCore/AIRuntime.swift
+++ b/Sources/SiliconScopeCore/AIRuntime.swift
@@ -1,7 +1,7 @@
 //
 //  File:      AIRuntime.swift
 //  Created:   2026-06-14
-//  Updated:   2026-08-07
+//  Updated:   2026-08-08
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Catalog + identity for local AI runtimes (Ollama, llama.cpp, LM Studio,
 //             MLX, Rapid-MLX, Jan, GPT4All, vLLM, exo). Pure logic — no syscalls; consumes
@@ -93,7 +93,15 @@ public enum AIRuntimeKind: String, Sendable, CaseIterable, Codable {
         if ["llama-server", "llama-cli", "llama-bench"].contains(base) { return .llamaCpp }
         if a.contains("mlx_lm.server") || a.contains("mlx_lm.generate") || a.contains("mlx_lm") { return .mlx }
         if base == "lms" || p.contains("LM Studio") || a.contains("LM Studio") { return .lmStudio }
-        if a.contains("vllm") || p.contains("vllm") { return .vllm }
+        // vLLM — OpenAI-compatible server launched via the `vllm` console entry point
+        // (/.../bin/vllm serve) or a Python module invocation (python -m vllm[.entrypoints]). The
+        // `vllm` console script is a shebang Python file, so on macOS proc_pidpath reports the
+        // interpreter (base "python*") and the script path lives in argv — `/bin/vllm` is the real
+        // signal there, mirroring exo's `/bin/exo`. `base == "vllm"` is a defensive fallback (a
+        // native build, or a proc table that reports the script). Every signal is bounded so a `vllm`
+        // username or a same-named source folder can't false-positive on the bare substring (mirrors
+        // the #38 jan/gpt4all bound and the exo arm's bounded-argv style).
+        if base == "vllm" || a.contains("/bin/vllm") || a.contains("-m vllm") || a.contains("vllm.entrypoints") { return .vllm }
         // exo (exo-explore/exo) — OpenAI-compatible cluster inference server on :52415. Match the
         // installed console entry point (basename `exo`), the source module file, or a `-m exo.main`
         // invocation. Every signal is bounded by a path separator or a leading space so unrelated

--- a/Tests/SiliconScopeCoreTests/AIRuntimeMatchTests.swift
+++ b/Tests/SiliconScopeCoreTests/AIRuntimeMatchTests.swift
@@ -1,7 +1,7 @@
 //
 //  File:      AIRuntimeMatchTests.swift
 //  Created:   2026-06-14
-//  Updated:   2026-08-07
+//  Updated:   2026-08-08
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Adversarial tests for AIRuntimeKind.match — the bundle-first, two-stage
 //             classifier. Locks in the cases that must NOT regress (Ollama runner is not
@@ -131,6 +131,54 @@ final class AIRuntimeMatchTests: XCTestCase {
                                            name: "Jan", args: nil), .jan)
         XCTAssertEqual(AIRuntimeKind.match(path: "/Applications/GPT4All.app/Contents/MacOS/gpt4all",
                                            name: "gpt4all", args: nil), .gpt4all)
+    }
+
+    // vLLM — `/.../bin/vllm serve` or `python -m vllm[.entrypoints]`. The console script is a
+    // shebang Python file, so macOS reports the interpreter and argv carries `/bin/vllm` (mirrors
+    // exo's `/bin/exo`) — which is why the positives below pass `path:` = the python binary.
+    func testVllmMatch() {
+        // Canonical launch via the console entry point. macOS exec's the shebang interpreter, so
+        // PATH is the python binary and the `vllm` script lives in argv as `/bin/vllm`.
+        XCTAssertEqual(AIRuntimeKind.match(path: "/Users/x/.venv/bin/python3.12", name: "python3.12",
+                                           args: "/Users/x/.venv/bin/python3.12 /Users/x/.venv/bin/vllm serve meta-llama/Llama-3-8B-Instruct"), .vllm)
+        // Module invocation via python — argv carries `-m vllm.entrypoints`.
+        XCTAssertEqual(AIRuntimeKind.match(path: "/opt/homebrew/bin/python3.12", name: "python3.12",
+                                           args: "python -m vllm.entrypoints.openai.api_server --model meta-llama/Llama-3-8B-Instruct"), .vllm)
+        // Bare `-m vllm` also resolves.
+        XCTAssertEqual(AIRuntimeKind.match(path: "/opt/homebrew/bin/python3.12", name: "python3.12",
+                                           args: "python -m vllm --model x"), .vllm)
+        // Glued `-mvllm.entrypoints` (no space) — isolates the `vllm.entrypoints` argv token, which
+        // the spaced `-m vllm` rule does not match.
+        XCTAssertEqual(AIRuntimeKind.match(path: "/opt/homebrew/bin/python3.12", name: "python3.12",
+                                           args: "python -mvllm.entrypoints.openai.api_server --model x"), .vllm)
+        // Defensive: an executable whose basename is literally `vllm` (a native build, or a proc
+        // table that reports the script) still resolves with no argv.
+        XCTAssertEqual(AIRuntimeKind.match(path: "/Users/x/.venv/bin/vllm", name: "vllm", args: nil), .vllm)
+    }
+
+    // A `vllm` SEGMENT in the path or argv (a username like /Users/vllm, a same-named checkout
+    // folder, or `pip install vllm`) must NOT be treated as the vLLM runtime — only the `vllm`
+    // entry-point path in argv, its basename, or a vLLM-module invocation is authoritative. The
+    // bare-substring rule matched all of these; this locks the false positive out on both the PATH
+    // and argv sides. Mirrors testExoDoesNotFalsePositive / #38.
+    func testVllmDoesNotFalsePositive() {
+        // PATH side — a `vllm` username is not the runtime (the motivating case).
+        XCTAssertNil(AIRuntimeKind.match(path: "/Users/vllm/codes", name: "vllm", args: nil))
+        XCTAssertNil(AIRuntimeKind.match(path: "/Users/vllm/.cache/pip/bin/pip", name: "pip", args: nil))
+        // PATH side — a `vllm` source-checkout folder running tests is not the runtime.
+        XCTAssertNil(AIRuntimeKind.match(path: "/Users/me/src/vllm/.venv/bin/pytest", name: "pytest", args: nil))
+        // argv side — `pip install vllm` installs the package, it does not serve a model. (Locks the
+        // argv bound: the PATH-side negatives above all have nil argv, so without this a bare
+        // `a.contains("vllm")` could return and no test would notice.)
+        XCTAssertNil(AIRuntimeKind.match(path: "/opt/homebrew/bin/python3.12", name: "python3.12",
+                                         args: "python -m pip install vllm"))
+        // argv side — a `vllm` username appearing in an argv script path is not the runtime.
+        XCTAssertNil(AIRuntimeKind.match(path: "/opt/homebrew/bin/python3.12", name: "python3.12",
+                                         args: "python /Users/vllm/train.py --port 8000"))
+        // Running the api_server module FILE directly (python …/vllm/entrypoints/openai/api_server.py)
+        // is an undocumented launch; the supported form is `vllm serve` / `python -m vllm.entrypoints…`.
+        XCTAssertNil(AIRuntimeKind.match(path: "/opt/homebrew/bin/python3.12", name: "python3.12",
+                                         args: "python /Users/me/src/vllm/vllm/entrypoints/openai/api_server.py"))
     }
 
     // primaryKind ranks by grouped RSS; the Ollama group (parent+runner) outweighs a small llama.cpp.


### PR DESCRIPTION
## Summary

`AIRuntimeKind.match` Stage 2 classified a process as the vLLM runtime whenever the bare substring `vllm` appeared anywhere in the executable path **or** argv — so a `vllm` **username** (`/Users/vllm/codes`), a same-named **source-checkout folder** (`/Users/me/src/vllm/…`), or even `pip install vllm` was silently reported as a running vLLM server. The substring is not a correct signal: vLLM is launched either through the `vllm` console entry point (`/.../bin/vllm serve`) or as a Python module (`python -m vllm[.entrypoints]`), both of which produce a bounded, unmistakable indicator. Binding the rule to those loses no legitimate detection while stopping the username/folder false positive. Mirrors the #38 jan/gpt4all bound and the `exo` arm's bounded-argv style directly below it.

## What this PR does

Replaces the bare `a.contains("vllm") || p.contains("vllm")` rule in `Sources/SiliconScopeCore/AIRuntime.swift` with:

```swift
if base == "vllm" || a.contains("/bin/vllm") || a.contains("-m vllm") || a.contains("vllm.entrypoints") { return .vllm }
```

- `a.contains("/bin/vllm")` — the real macOS signal. The `vllm` console script is a shebang Python file, so `proc_pidpath` reports the interpreter (basename `python*`) and the script path lives in argv as `…/bin/vllm`. Catches `vllm serve` via venv / uvx / `uv run` / pipx / pip — the same reasoning as `exo`'s `a.contains("/bin/exo")`.
- `a.contains("-m vllm")` / `a.contains("vllm.entrypoints")` — the `python -m vllm` / `python -m vllm.entrypoints.openai.api_server` module invocations.
- `base == "vllm"` — defensive fallback (a native build, or a proc table that reports the script).

No other runtime rule, no `displayName`, no enum change, no new deps, Core-only (no `SwiftUI`). The #38 (jan/gpt4all) and #39 (volume-clamp) changes are untouched.

## Test plan

Mirrors the existing `testExoDoesNotFalsePositive` and #38's `testJanGpt4allDoNotFalsePositive`, which lock the same class of bug (short-substring false-positive) for `exo` / `jan` / `gpt4all`.

- [x] `xcrun swift build` -> `Build complete!` (exit 0)
- [x] `xcrun swift test` -> **169 tests, 0 failures** (baseline 167, +2 = `testVllmMatch` + `testVllmDoesNotFalsePositive`)
- [x] `xcrun swift test --filter AIRuntimeMatchTests` -> 15/15 pass
- [x] Red proven: with the bare `a/p.contains("vllm")` rule, `testVllmDoesNotFalsePositive` fails on the path-side cases (`/Users/vllm/codes`, `/Users/vllm/.cache/pip/bin/pip`, `/Users/me/src/vllm/.venv/bin/pytest`) **and** the argv-side cases (`pip install vllm`, username-in-argv); bounded rule -> green
- [x] Realistic positives: the `vllm serve` case uses the sampler's actual output (PATH = the python interpreter, argv carries `/bin/vllm`), not a synthetic script path — so the test would catch a rule that misses the canonical launch
- [x] `git diff --name-only main...HEAD` -> exactly `Sources/SiliconScopeCore/AIRuntime.swift` + `Tests/SiliconScopeCoreTests/AIRuntimeMatchTests.swift`

---

Drafted with AI assistance (Claude Code); reviewed and tested locally on Apple Silicon.
