### PR TITLE
fix(sensors): fpe2 SMC keys lose their fraction — decode the full fixed-point value

### DIFF
--- a/Sources/SiliconScopeCore/SMCReader.swift
+++ b/Sources/SiliconScopeCore/SMCReader.swift
@@ -1,13 +1,16 @@
 //
 //  File:      SMCReader.swift
 //  Created:   2026-06-08
-//  Updated:   2026-06-24
+//  Updated:   2026-08-08
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Minimal read-only Apple SMC client (sudoless) for fan speed and other
 //             scalar keys. Opens the AppleSMC IOService and reads keys via the fixed
 //             kernel ABI: readKeyInfo (cmd 9) then readBytes (cmd 5).
 //  Notes:     SMCKeyData layout MUST match the kernel struct exactly (do not reorder).
 //             Decodes flt/ui8/ui16/ui32/fpe2. Read-only — never writes SMC keys.
+//             fpe2 is a 16-bit big-endian fixed-point with 2 fractional bits (true value =
+//             raw uint16 / 4); the scalar decode lives in the pure `decode(type:bytes:)` so
+//             it can be unit-tested without hardware (Apple SMC fixed-point convention).
 //
 import Foundation
 import IOKit
@@ -61,12 +64,25 @@ final class SMCReader {
     /// Reads a scalar SMC key as Double, or nil if missing/unsupported type.
     func readDouble(_ key: String) -> Double? {
         guard let (type, bytes) = readKey(key) else { return nil }
+        return Self.decode(type: type, bytes: bytes)
+    }
+
+    /// Pure scalar decode for an SMC value: maps a FourCC type + its raw bytes to a Double.
+    /// Extracted from the hardware-coupled reader so it is unit-testable in isolation — this is
+    /// the gateway for every SMC scalar (curated temps, fan RPM, FNum, and the power/current/
+    /// voltage rails surfaced by `allKeys`/`allTemperatureKeys`), so a wrong case here warps them all.
+    static func decode(type: String, bytes: [UInt8]) -> Double? {
         switch type {
         case "ui8 ": return Double(bytes[0])
         case "ui16": return Double(UInt16(bytes[0]) << 8 | UInt16(bytes[1]))
         case "ui32": return Double((UInt32(bytes[0]) << 24) | (UInt32(bytes[1]) << 16) | (UInt32(bytes[2]) << 8) | UInt32(bytes[3]))
         case "flt ": return Double(bytes.withUnsafeBytes { $0.loadUnaligned(as: Float.self) })
-        case "fpe2": return Double((Int(bytes[0]) << 6) + (Int(bytes[1]) >> 2))
+        case "fpe2":
+            // 16-bit big-endian fixed-point, 2 fractional bits: true value = raw uint16 / 4.
+            // The old `(b0 << 6) + (b1 >> 2)` shifted the low 2 bits away, flooring every fpe2 key.
+            guard bytes.count >= 2 else { return nil }
+            let raw = (UInt16(bytes[0]) << 8) | UInt16(bytes[1])
+            return Double(raw) / 4.0
         default: return nil
         }
     }

--- a/Tests/SiliconScopeCoreTests/SMCDecodeTests.swift
+++ b/Tests/SiliconScopeCoreTests/SMCDecodeTests.swift
@@ -1,0 +1,89 @@
+//
+//  File:      SMCDecodeTests.swift
+//  Created:   2026-08-08
+//  Updated:   2026-08-08
+//  Developer: Yurii Chukhlib
+//  Overview:  Unit tests for SMCReader.decode(type:bytes:) — the pure scalar decode extracted
+//             from the hardware-coupled reader. Pins the fpe2 fixed-point value at FULL precision
+//             (the bug: the old `(b0 << 6) + (b1 >> 2)` shift discarded the low 2 bits, flooring
+//             every fpe2 power/current/voltage key to a whole number) and locks the other scalar
+//             types (flt/ui8/ui16/ui32) so the extraction is a behaviour-preserving refactor.
+//  Notes:     fpe2 is Apple SMC's 16-bit big-endian fixed-point with 2 fractional bits: the true
+//             value is raw_uint16 / 4. No hardware: decode is a static fn over explicit byte arrays,
+//             so the fractional cases that the old shift lost are pinned here deterministically.
+//
+import XCTest
+@testable import SiliconScopeCore
+
+final class SMCDecodeTests: XCTestCase {
+
+    // MARK: - fpe2: 16-bit big-endian fixed-point, 2 fractional bits (value = raw uint16 / 4)
+
+    /// The headline regression: bytes [0x00, 0x33] = raw 51 must decode to 12.75, not 12.0.
+    /// The old `(Int(b0) << 6) + (Int(b1) >> 2)` returned 12.0 — it shifted away the .75.
+    func testFpe2KeepsTheFraction() {
+        XCTAssertEqual(SMCReader.decode(type: "fpe2", bytes: [0x00, 0x33]), 12.75)
+    }
+
+    /// Every fractional step a 2-bit fixed-point can express must survive the decode.
+    func testFpe2QuarterSteps() {
+        XCTAssertEqual(SMCReader.decode(type: "fpe2", bytes: [0x00, 0x01]), 0.25)
+        XCTAssertEqual(SMCReader.decode(type: "fpe2", bytes: [0x00, 0x02]), 0.50)
+        XCTAssertEqual(SMCReader.decode(type: "fpe2", bytes: [0x00, 0x03]), 0.75)
+    }
+
+    /// Boundaries of the fixed-point: raw 0 → 0.0, raw 4 → 1.0 (the smallest whole step).
+    func testFpe2Boundaries() {
+        XCTAssertEqual(SMCReader.decode(type: "fpe2", bytes: [0x00, 0x00]), 0.0)
+        XCTAssertEqual(SMCReader.decode(type: "fpe2", bytes: [0x00, 0x04]), 1.0)
+    }
+
+    /// Big-endian high byte carries weight: [0x01, 0x00] = raw 256 → 64.0 (a whole value, so it
+    /// also confirms the extraction did not regress the high-byte path the old formula shared).
+    func testFpe2BigEndianHighByte() {
+        XCTAssertEqual(SMCReader.decode(type: "fpe2", bytes: [0x01, 0x00]), 64.0)
+    }
+
+    /// Full-scale: raw 0xFFFF (65535) → 16383.75 (the .75 is exactly what the old shift dropped).
+    func testFpe2FullScale() {
+        XCTAssertEqual(SMCReader.decode(type: "fpe2", bytes: [0xFF, 0xFF]), 16383.75)
+    }
+
+    /// The `bytes.count >= 2` guard: a short buffer returns nil rather than trapping.
+    /// Defensive — `readDouble` always supplies the key's full byte width — but `decode` is now a
+    /// directly-callable static fn, so its own contract must be crash-free on bad input.
+    func testFpe2RejectsShortBuffer() {
+        XCTAssertNil(SMCReader.decode(type: "fpe2", bytes: []))
+        XCTAssertNil(SMCReader.decode(type: "fpe2", bytes: [0x00]))
+    }
+
+    // MARK: - Other scalar types: the extraction must be a behaviour-preserving refactor
+
+    func testUi8() {
+        XCTAssertEqual(SMCReader.decode(type: "ui8 ", bytes: [0x2A]), 42.0)
+    }
+
+    /// [0x01, 0x2C] = 300 (big-endian).
+    func testUi16BigEndian() {
+        XCTAssertEqual(SMCReader.decode(type: "ui16", bytes: [0x01, 0x2C]), 300.0)
+    }
+
+    /// [0x00, 0x01, 0x86, 0x9F] = 99999 (big-endian).
+    func testUi32BigEndian() {
+        XCTAssertEqual(SMCReader.decode(type: "ui32", bytes: [0x00, 0x01, 0x86, 0x9F]), 99999.0)
+    }
+
+    /// flt is a native-endian IEEE-754 load; build the bytes in the platform's own byte order so
+    /// the test is self-consistent with how decode's loadUnaligned reads them, regardless of endian.
+    func testFlt() throws {
+        var bits: UInt32 = 0x4048F5C3   // float bits for 3.14
+        let bytes = withUnsafeBytes(of: &bits) { Array($0) }
+        let value = try XCTUnwrap(SMCReader.decode(type: "flt ", bytes: bytes))
+        XCTAssertEqual(value, 3.14, accuracy: 1e-6)
+    }
+
+    /// An unknown type falls through to nil (the default arm), never a crash.
+    func testUnknownTypeReturnsNil() {
+        XCTAssertNil(SMCReader.decode(type: "ch8*", bytes: [0x41, 0x42]))
+    }
+}


### PR DESCRIPTION
fix(sensors): fpe2 SMC keys lose their fraction — decode the full fixed-point value

## The bug

`SMCReader.readDouble(_:)` decoded `fpe2`-typed SMC keys with

```swift
case "fpe2": return Double((Int(bytes[0]) << 6) + (Int(bytes[1]) >> 2))
```

`fpe2` is Apple SMC's 16-bit big-endian fixed-point with **2 fractional bits** (true value =
`raw_uint16 / 4`). The expression `(b0 << 6) + (b1 >> 2)` is algebraically `b0*64 + floor(b1/4)` =
`floor(raw / 4)` — it shifts the low 2 bits away, **flooring every `fpe2` value to a whole number**
and losing the `.25/.5/.75`. Bytes `[0x00, 0x33]` (raw 51) decode to **12.0** instead of **12.75**.

`readDouble` is the gateway for **every** SMC scalar — the curated temperatures, fan RPM, `FNum`, the
A18 `PSTR`/`PZC0` power rails, and the `--smc-all` / `--sensors-all` dumps — so any `fpe2`-typed key
(power/current/voltage rails) reads truncated.

## What this PR does

1. **Extracts the scalar decode into a pure, hardware-free function.** The switch moves out of the
   IOKit-coupled `readDouble` into `static func decode(type: String, bytes: [UInt8]) -> Double?`, and
   `readDouble` delegates via `Self.decode(...)`. This is the repo's established pattern (Bottleneck,
   BandwidthSampler.classify, BatterySampler.healthPercent, MetricsEngine) — pure logic lifted out of
   a hardware-coupled sampler so it can be unit-tested. The `ui8/ui16/ui32/flt` cases are copied
   **verbatim** (a behaviour-preserving refactor; pinned by parity tests).
2. **Fixes the `fpe2` case** to decode the true fixed-point value:
   ```swift
   guard bytes.count >= 2 else { return nil }
   let raw = (UInt16(bytes[0]) << 8) | UInt16(bytes[1])
   return Double(raw) / 4.0
   ```
   big-endian `UInt16` read, divide by `4.0` (keeps the fraction), with a short-buffer guard.
3. **Adds `SMCDecodeTests`** (11 tests) pinning the fpe2 fraction at full precision and locking the
   other scalar types so the extraction is provably behaviour-preserving.

### Why `raw / 4.0` is correct

Cross-checked against five independent SMC implementations — `fpe2` is a **16-bit, big-endian,
unsigned** fixed-point with **2 fractional bits** (`value = raw_uint16 / 4`):

- **smcFanControl** — `ntohs(*(UInt16*)val.bytes) / 4.0` (big-endian, unsigned, **float**).
- **osx-cpu-temp** — `… * 256 + … ; return / 4.0` (**float**).
- Linux `drivers/hwmon/applesmc.c` — `(buffer[0] << 8 | buffer[1]) >> 2`, `unsigned int`.
- QEMU applesmc — "fpe2 encoding (raw = RPM * 4, big-endian)".
- **exelban/stats** (Swift) — `(Int(b0) << 6) + (Int(b1) >> 2)`.

The old SiliconScope formula is byte-for-byte identical to the Linux/exelban **integer-floor**
variant — fine for *integer RPM display* (fans), which is what those projects use it for, but wrong
for the power/current/voltage rails SiliconScope surfaces, where `.25/.5/.75` matter. The float
`/4.0` matches smcFanControl and osx-cpu-temp. (`fpe2` is unsigned; the `sp78/sp87` family is the
signed one — not decoded here.)

## Test plan

- [x] `xcrun swift build` — clean.
- [x] `xcrun swift test` — **178/178 pass, 0 failures** (11 new: `SMCDecodeTests`).
- [x] RED before the fix — `xcrun swift test --filter SMCDecodeTests` → 5 failures, all the
      fractional cases: `[0x00,0x33]` returned `12.0` not `12.75`; `[0x00,0x01/02/03]` returned
      `0.0` not `0.25/0.50/0.75`; `[0xFF,0xFF]` returned `16383.0` not `16383.75`. GREEN after.
- [x] Extraction parity — `flt`/`ui8`/`ui16`/`ui32` decode identically through the extracted
      `decode` (non-trivial multi-byte values; the fpe2 whole-value cases pass under both formulas,
      confirming the refactor changed nothing but the fraction).
- [ ] Live `fpe2` rail on real hardware — the read path (`readDouble` → IOKit) is hardware-coupled
      and out of scope for this PR (pure decode only). Worth confirming a power/current rail on an
      M-series Mac via `xcrun swift run -q sscope-cli --sensors` now reads a non-integer value;
      flagging rather than claiming it.

## Notes / scope

- The `bytes.count >= 2` guard is `fpe2`-only by design (the spec scoped it there); `readDouble`
  always supplies the key's full byte width, so the other arms never see short input. Making
  `decode` uniformly crash-free on bad input is a reasonable follow-up but is intentionally out of
  scope for this focused fix.
- Read-only — no SMC keys are written. No SwiftUI, telemetry, or CLI-flag changes in Core.
