### PR TITLE
fix(bandwidth): treat IOReport INT64_MIN as an unpopulated channel

### DIFF
--- a/Sources/SiliconScopeCore/BandwidthSampler.swift
+++ b/Sources/SiliconScopeCore/BandwidthSampler.swift
@@ -1,7 +1,7 @@
 //
 //  File:      BandwidthSampler.swift
 //  Created:   2026-06-08
-//  Updated:   2026-07-21
+//  Updated:   2026-08-09
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Reads unified-memory bandwidth (GB/s) sudolessly. Three read strategies,
 //             tried in order at init and locked in for the sampler's lifetime:
@@ -138,6 +138,22 @@ public final class BandwidthSampler {
         }
     }
 
+    // MARK: - Simple-format channel value handling
+
+    /// Returns the byte delta for an IOReport "Simple" bandwidth channel, treating the documented
+    /// `INT64_MIN` "unpopulated" sentinel as 0. IOReport fills a Simple channel it has no reading
+    /// for this period with `INT64_MIN` (the same value `channelDump()` labels "not populated, raw
+    /// INT64_MIN"); summed as a real value it swamps/corrupts the per-bus total — one dead lane
+    /// yields `Double(Int.min)` ≈ -9.2e18 bytes, a huge-negative GB/s for the whole bus — so the
+    /// sentinel must be stripped before the value enters the delta or sum. This is an IOReport-wide
+    /// convention, not a bandwidth one: `PowerSampler.sample()` (`PowerSampler.swift:82`) reads the
+    /// same C API unguarded — its fix (a separate PR, per this fork's PR-split plan) should promote/
+    /// reuse this helper rather than re-deriving `raw == Int.min ? 0`. Pure (Int → Int) so the
+    /// `Int.min` boundary is unit-testable without IOReport hardware.
+    static func sanitizeSimpleValue(_ raw: Int) -> Int {
+        raw == Int.min ? 0 : raw
+    }
+
     // MARK: - A18: PMP "DRAM BW" frequency-state lanes (Simple format, bytes)
 
     /// Sum the PMP "DRAM BW" frequency-state lanes (F1–F5 RD/WR, bytes) for the total.
@@ -153,7 +169,7 @@ public final class BandwidthSampler {
             else { return Int32(kKtopIOReportIterOk) }
             let name = (nameRef as String).uppercased()
             guard name.hasSuffix(" RD") || name.hasSuffix(" WR") else { return Int32(kKtopIOReportIterOk) }
-            totalBytes += Double(IOReportSimpleGetIntegerValue(channel, 0))
+            totalBytes += Double(Self.sanitizeSimpleValue(IOReportSimpleGetIntegerValue(channel, 0)))
             return Int32(kKtopIOReportIterOk)
         }
         var result = BandwidthSample()
@@ -185,7 +201,8 @@ public final class BandwidthSampler {
                 return Int32(kKtopIOReportIterOk)
             }
             let requestor = Self.stripReadWriteSuffix(name)
-            let gbs = (Double(IOReportSimpleGetIntegerValue(channel, 0)) / seconds) / 1_000_000_000.0
+            let raw = Self.sanitizeSimpleValue(IOReportSimpleGetIntegerValue(channel, 0))
+            let gbs = (Double(raw) / seconds) / 1_000_000_000.0
 
             switch Self.classify(requestor: requestor) {
             case .total: total += gbs    // "DCS" chip-wide aggregate = true total

--- a/Tests/SiliconScopeCoreTests/BandwidthSimpleSentinelTests.swift
+++ b/Tests/SiliconScopeCoreTests/BandwidthSimpleSentinelTests.swift
@@ -1,0 +1,70 @@
+//
+//  File:      BandwidthSimpleSentinelTests.swift
+//  Created:   2026-08-09
+//  Updated:   2026-08-09
+//  Developer: Yurii Chukhlib
+//  Overview:  Unit tests for `BandwidthSampler.sanitizeSimpleValue` — the guard that stops an
+//             IOReport "Simple" bandwidth channel's documented `INT64_MIN` "unpopulated" sentinel
+//             from being summed/averaged as a real byte delta.
+//  Notes:     No hardware: these exercise a pure Int → Int helper, the boundary that's impossible
+//             to hit deterministically through `sample()` (which needs a live IOReport subscription
+//             and an unpopulated channel). The sentinel is the same value `channelDump()` already
+//             labels "not populated, raw INT64_MIN"; this test pins the behavior at the read/
+//             accumulate site so a single unpopulated lane can no longer corrupt the whole bus's
+//             GB/s (the pre-fix failure: `Double(Int.min)` ≈ -9.2e18 bytes dominates the sum).
+//
+import XCTest
+@testable import SiliconScopeCore
+
+final class BandwidthSimpleSentinelTests: XCTestCase {
+
+    // MARK: - INT64_MIN "unpopulated" sentinel → 0
+
+    /// The documented IOReport "unpopulated" sentinel (`Int64.min`, which is `Int.min` on the
+    /// 64-bit target) must read as "no data" (0), not as a real byte delta. Before this guard
+    /// existed it was summed straight into the per-bus total, producing a huge-negative GB/s.
+    func testSentinelMapsToZero() {
+        // `.min` resolves to `Int.min` (== Int64.min == INT64_MIN on the 64-bit target).
+        XCTAssertEqual(BandwidthSampler.sanitizeSimpleValue(.min), 0,
+                       "INT64_MIN / Int.min 'unpopulated' sentinel reads as 0, not a real byte delta")
+    }
+
+    // MARK: - Real readings pass through unchanged
+
+    func testNormalReadingPassesThrough() {
+        XCTAssertEqual(BandwidthSampler.sanitizeSimpleValue(0), 0)
+        XCTAssertEqual(BandwidthSampler.sanitizeSimpleValue(1_500_000_000), 1_500_000_000)
+        XCTAssertEqual(BandwidthSampler.sanitizeSimpleValue(2_000_000_000_000), 2_000_000_000_000)
+    }
+
+    /// Only `Int.min` is the documented sentinel. A real, non-sentinel negative value is NOT a
+    /// sentinel and must survive unchanged — the guard must not silently zero legitimate data.
+    func testNonSentinelNegativePassesThrough() {
+        XCTAssertEqual(BandwidthSampler.sanitizeSimpleValue(-1), -1)
+        // Int.min + 1 is the largest-in-magnitude negative that is NOT the sentinel.
+        XCTAssertEqual(BandwidthSampler.sanitizeSimpleValue(Int.min + 1), Int.min + 1)
+    }
+
+    // MARK: - The sentinel no longer corrupts a per-bus sum
+
+    /// Two live DRAM-BW lanes plus one unpopulated lane (the sentinel). Pre-fix, the unguarded
+    /// `Double(Int.min)` ≈ -9.2e18 dominated the sum; post-fix the dead lane contributes 0, so the
+    /// bus total is just the two live lanes. This is the A18 `sampleA18Simple` total-accumulation
+    /// shape and the M-series `sampleAMCStatsSimple` per-requestor accumulation shape, in miniature.
+    func testSentinelLaneDoesNotCorruptSum() {
+        let lanes = [2_000_000_000, 3_000_000_000, Int.min]   // two live lanes + one unpopulated
+        let totalBytes = lanes.reduce(0.0) { $0 + Double(BandwidthSampler.sanitizeSimpleValue($1)) }
+        XCTAssertEqual(totalBytes, 5_000_000_000, accuracy: 1e-6,
+                       "the unpopulated lane must contribute 0, leaving only the two live lanes")
+    }
+
+    /// Documents the exact corruption the guard prevents: the same lanes summed *without* the guard.
+    /// It is wildly negative — what a user would have seen before this fix. Kept as a regression
+    /// witness so the failure mode is self-explanatory if the guard is ever removed.
+    func testDocumentsThePreFixCorruption() {
+        let lanes = [2_000_000_000, 3_000_000_000, Int.min]
+        let unguarded = lanes.reduce(0.0) { $0 + Double($1) }
+        XCTAssertLessThan(unguarded, -1e18,
+                          "pre-fix: Double(Int.min) ≈ -9.2e18 dominates the sum — an overflow-scale value, the bug this guard fixes")
+    }
+}


### PR DESCRIPTION
## Summary

A single IOReport "Simple" bandwidth channel that is **not populated** for a sampling period
returns the documented `INT64_MIN` sentinel. `BandwidthSampler` summed that raw value straight
into its per-bus byte totals, so **one dead lane corrupted the entire bus's reading**:
`Double(Int64.min)` ≈ -9.2×10¹⁸ bytes → a huge-negative / overflowed GB/s for the whole bus.

This PR guards the Simple-format channel value: `INT64_MIN` is treated as 0 ("unpopulated")
before it enters the delta or sum, mirroring the sentinel convention this file's own
`channelDump()` diagnostic already labels *"not populated, raw INT64_MIN"*.

## Root cause

`IOReportSimpleGetIntegerValue` (`extern long`, → Swift `Int` on the 64-bit target) fills a
Simple channel it has no reading for with `INT64_MIN`. Both Simple-format sample paths used the
raw value unguarded:

- `sampleA18Simple` — `totalBytes += Double(IOReportSimpleGetIntegerValue(channel, 0))`
- `sampleAMCStatsSimple` — `gbs = (Double(IOReportSimpleGetIntegerValue(channel, 0)) / seconds) / 1e9`

So one unpopulated lane produced `Double(Int64.min)` ≈ -9.2e18, which dominates any realistic
byte total and yields a garbage GB/s figure for the bus.

## Fix

Localized to the value-sentinel handling only — the IOReport subscription/setup is untouched.

```swift
// Sources/SiliconScopeCore/BandwidthSampler.swift
static func sanitizeSimpleValue(_ raw: Int) -> Int {
    raw == Int.min ? 0 : raw
}
```

Both Simple read sites now route through it:

```swift
totalBytes += Double(Self.sanitizeSimpleValue(IOReportSimpleGetIntegerValue(channel, 0)))   // A18
let gbs = (Double(Self.sanitizeSimpleValue(IOReportSimpleGetIntegerValue(channel, 0))) / seconds) / 1e9  // AMC
```

The `Int.min` sentinel → 0 mapping matches the project's existing convention exactly
(`channelDump()`: `if raw == Int.min { … "not populated, raw INT64_MIN" }`). The State-format
PMP-histogram path (`samplePMPHistogram`, `IOReportStateGetResidency`) is a different API and is
correctly **not** touched.

## Test

New pure unit test — no IOReport hardware, no `Thread.sleep`, no subscription
(`Tests/SiliconScopeCoreTests/BandwidthSimpleSentinelTests.swift`). It exercises the sentinel
boundary directly: `Int.min` → 0, `Int.min + 1` and a normal reading pass through unchanged,
and a per-bus sum with one unpopulated lane no longer corrupts.

**RED → GREEN** (empirically verified): with the helper temporarily made an identity (the
pre-fix behavior), `testSentinelMapsToZero` and `testSentinelLaneDoesNotCorruptSum` **fail** —
the sum reads `-9.223372031854776e+18` instead of `5_000_000_000`. With the real guard
restored, all 5 new tests pass.

## Gate

`xcrun swift build && xcrun swift test` — green. **172 tests, 0 failures** (was 167; +5 from
the new test file).

## Scope

- **Touches:** `Sources/SiliconScopeCore/BandwidthSampler.swift` (1 pure helper + 2 call-site
  reroutes + header date) and the new test file only.
- **Does NOT touch:** IOReport handle/subscription setup, the State-format PMP-histogram path,
  or any other sampler. (`PowerSampler` has the same unguarded-Simple pattern and is deliberately
  left for a separate PR — different files, per the contributor's PR-split plan.)

No telemetry, no sudo, no SwiftUI in Core. No AI-branding policy on this repo; no DCO.
