### PR TITLE
fix(power): treat an IOReport INT64_MIN energy rail as unpopulated

### DIFF
--- a/Sources/SiliconScopeCore/BandwidthSampler.swift
+++ b/Sources/SiliconScopeCore/BandwidthSampler.swift
@@ -139,20 +139,9 @@ public final class BandwidthSampler {
     }
 
     // MARK: - Simple-format channel value handling
-
-    /// Returns the byte delta for an IOReport "Simple" bandwidth channel, treating the documented
-    /// `INT64_MIN` "unpopulated" sentinel as 0. IOReport fills a Simple channel it has no reading
-    /// for this period with `INT64_MIN` (the same value `channelDump()` labels "not populated, raw
-    /// INT64_MIN"); summed as a real value it swamps/corrupts the per-bus total — one dead lane
-    /// yields `Double(Int.min)` ≈ -9.2e18 bytes, a huge-negative GB/s for the whole bus — so the
-    /// sentinel must be stripped before the value enters the delta or sum. This is an IOReport-wide
-    /// convention, not a bandwidth one: `PowerSampler.sample()` (`PowerSampler.swift:82`) reads the
-    /// same C API unguarded — its fix (a separate PR, per this fork's PR-split plan) should promote/
-    /// reuse this helper rather than re-deriving `raw == Int.min ? 0`. Pure (Int → Int) so the
-    /// `Int.min` boundary is unit-testable without IOReport hardware.
-    static func sanitizeSimpleValue(_ raw: Int) -> Int {
-        raw == Int.min ? 0 : raw
-    }
+    // The documented `INT64_MIN` "unpopulated" sentinel is stripped via the shared
+    // `IOReportNaming.sanitizeSimpleValue` — an IOReport-wide convention the power sampler shares,
+    // so the guard lives once rather than being re-derived per sampler.
 
     // MARK: - A18: PMP "DRAM BW" frequency-state lanes (Simple format, bytes)
 
@@ -169,7 +158,7 @@ public final class BandwidthSampler {
             else { return Int32(kKtopIOReportIterOk) }
             let name = (nameRef as String).uppercased()
             guard name.hasSuffix(" RD") || name.hasSuffix(" WR") else { return Int32(kKtopIOReportIterOk) }
-            totalBytes += Double(Self.sanitizeSimpleValue(IOReportSimpleGetIntegerValue(channel, 0)))
+            totalBytes += Double(IOReportNaming.sanitizeSimpleValue(IOReportSimpleGetIntegerValue(channel, 0)))
             return Int32(kKtopIOReportIterOk)
         }
         var result = BandwidthSample()
@@ -201,7 +190,7 @@ public final class BandwidthSampler {
                 return Int32(kKtopIOReportIterOk)
             }
             let requestor = Self.stripReadWriteSuffix(name)
-            let raw = Self.sanitizeSimpleValue(IOReportSimpleGetIntegerValue(channel, 0))
+            let raw = IOReportNaming.sanitizeSimpleValue(IOReportSimpleGetIntegerValue(channel, 0))
             let gbs = (Double(raw) / seconds) / 1_000_000_000.0
 
             switch Self.classify(requestor: requestor) {

--- a/Sources/SiliconScopeCore/IOReportNaming.swift
+++ b/Sources/SiliconScopeCore/IOReportNaming.swift
@@ -3,12 +3,13 @@
 //  Created:   2026-08-10
 //  Updated:   2026-08-10
 //  Developer: Kennt Kim / Calida Lab
-//  Overview:  How IOReport spells the names this project matches on. Apple prefixes group and
-//             channel names with a die/chip-id token on some OS versions and some parts — the
-//             bandwidth group's "ECPU" became "DIE0 ECPU0" on a macOS 27 beta (#14), and a
-//             reporter saw "PRIM MCPU0 DCS" on M5 Max (#30). A sampler that matches the bare
-//             name reads 0 on those machines while every other panel keeps working.
-//  Notes:     Two shapes, both anchored so an unrelated substring cannot match:
+//  Overview:  The IOReport conventions every sampler shares — how it spells its names, and the
+//             sentinel value of its "Simple" format. Apple prefixes group and channel names with a
+//             die/chip-id token on some OS versions and some parts — the bandwidth group's "ECPU"
+//             became "DIE0 ECPU0" on a macOS 27 beta (#14), and a reporter saw "PRIM MCPU0 DCS" on
+//             M5 Max (#30). A sampler that matches the bare name reads 0 on those machines while
+//             every other panel keeps working.
+//  Notes:     Two name shapes, both anchored so an unrelated substring cannot match:
 //             - `isUnit`      — the whole unit name ("CPU Energy", "GPU Energy", PMP's "ECPU")
 //             - `hasUnitPrefix` — a unit family whose members carry numeric suffixes
 //               ("GPU0", "ANE1", "EACC_CPU"), so new core/cluster counts need no code change.
@@ -16,6 +17,11 @@
 //             is the only shape Apple has used. This deliberately does NOT try to recognise which
 //             tokens are die ids: enumerating them would be guessing at names we have never seen,
 //             and the anchor (a leading space) is what makes the match safe without that guess.
+//             `sanitizeSimpleValue` is the OTHER shared convention: an IOReport "Simple" channel
+//             it has no reading for this period is filled with `INT64_MIN`, which summed as a real
+//             value swamps the whole rail (one dead lane yields `Double(Int.min)` ≈ -9.2e18). The
+//             bandwidth sampler and the power sampler hit the same C API, so the guard that strips
+//             the sentinel lives here once rather than being re-derived per sampler.
 //
 import Foundation
 
@@ -43,5 +49,17 @@ public enum IOReportNaming {
     /// "GPU SRAM") would be cut in half — use `isUnit` for those.
     public static func unitToken(_ name: String) -> String {
         name.split(separator: " ").last.map(String.init) ?? name
+    }
+
+    /// Returns the byte/energy delta of an IOReport "Simple" channel, treating the documented
+    /// `INT64_MIN` "unpopulated" sentinel as 0. IOReport fills a Simple channel it has no reading
+    /// for this period with `INT64_MIN` (the same value `channelDump()` labels "not populated, raw
+    /// INT64_MIN"); summed as a real value it swamps/corrupts the per-rail total — one dead lane
+    /// yields `Double(Int.min)` ≈ -9.2e18, a huge-negative GB/s or W for the whole rail — so the
+    /// sentinel must be stripped before the value enters a delta or sum. Pure (Int → Int) so the
+    /// `Int.min` boundary is unit-testable without IOReport hardware, and shared so the bandwidth
+    /// and power samplers cannot drift apart on the same C API convention.
+    static func sanitizeSimpleValue(_ raw: Int) -> Int {
+        raw == Int.min ? 0 : raw
     }
 }

--- a/Sources/SiliconScopeCore/PowerSampler.swift
+++ b/Sources/SiliconScopeCore/PowerSampler.swift
@@ -99,8 +99,7 @@ public final class PowerSampler {
 
             let group = groupRef as String
             let name = nameRef as String
-            let milliJoules = Double(IOReportSimpleGetIntegerValue(channel, 0))
-            let watts = (milliJoules / seconds) / 1000.0
+            let watts = Self.simpleWatts(raw: IOReportSimpleGetIntegerValue(channel, 0), seconds: seconds)
 
             // Group and channel names are matched through IOReportNaming so a die/chip-id token
             // ("DIE0 Energy Model", "DIE0 GPU0") still resolves — the shape that broke the
@@ -204,6 +203,17 @@ public final class PowerSampler {
         }
 
         return result
+    }
+
+    /// Watts from one IOReport "Simple" energy channel over `seconds`: strips the documented
+    /// `INT64_MIN` "unpopulated" sentinel (via the shared `IOReportNaming.sanitizeSimpleValue`)
+    /// before the mJ → W conversion. Energy Model channels are millijoules; the same sentinel that
+    /// corrupts a bandwidth bus corrupts a power rail — one unpopulated rail yielded
+    /// `Double(Int.min)` ≈ -9.2e18 mJ, a huge-negative wattage that dominated the per-domain sum.
+    /// Pure (Int + TimeInterval → Double) so the `Int.min` boundary is unit-testable without an
+    /// IOReport subscription.
+    static func simpleWatts(raw: Int, seconds: TimeInterval) -> Double {
+        Double(IOReportNaming.sanitizeSimpleValue(raw)) / seconds / 1000.0
     }
 
     /// One IOReport "Simple" (energy) channel, as read for a diagnostic dump.

--- a/Tests/SiliconScopeCoreTests/BandwidthSimpleSentinelTests.swift
+++ b/Tests/SiliconScopeCoreTests/BandwidthSimpleSentinelTests.swift
@@ -1,9 +1,9 @@
 //
 //  File:      BandwidthSimpleSentinelTests.swift
 //  Created:   2026-08-09
-//  Updated:   2026-08-09
+//  Updated:   2026-08-10
 //  Developer: Yurii Chukhlib
-//  Overview:  Unit tests for `BandwidthSampler.sanitizeSimpleValue` — the guard that stops an
+//  Overview:  Unit tests for `IOReportNaming.sanitizeSimpleValue` — the guard that stops an
 //             IOReport "Simple" bandwidth channel's documented `INT64_MIN` "unpopulated" sentinel
 //             from being summed/averaged as a real byte delta.
 //  Notes:     No hardware: these exercise a pure Int → Int helper, the boundary that's impossible
@@ -25,24 +25,24 @@ final class BandwidthSimpleSentinelTests: XCTestCase {
     /// existed it was summed straight into the per-bus total, producing a huge-negative GB/s.
     func testSentinelMapsToZero() {
         // `.min` resolves to `Int.min` (== Int64.min == INT64_MIN on the 64-bit target).
-        XCTAssertEqual(BandwidthSampler.sanitizeSimpleValue(.min), 0,
+        XCTAssertEqual(IOReportNaming.sanitizeSimpleValue(.min), 0,
                        "INT64_MIN / Int.min 'unpopulated' sentinel reads as 0, not a real byte delta")
     }
 
     // MARK: - Real readings pass through unchanged
 
     func testNormalReadingPassesThrough() {
-        XCTAssertEqual(BandwidthSampler.sanitizeSimpleValue(0), 0)
-        XCTAssertEqual(BandwidthSampler.sanitizeSimpleValue(1_500_000_000), 1_500_000_000)
-        XCTAssertEqual(BandwidthSampler.sanitizeSimpleValue(2_000_000_000_000), 2_000_000_000_000)
+        XCTAssertEqual(IOReportNaming.sanitizeSimpleValue(0), 0)
+        XCTAssertEqual(IOReportNaming.sanitizeSimpleValue(1_500_000_000), 1_500_000_000)
+        XCTAssertEqual(IOReportNaming.sanitizeSimpleValue(2_000_000_000_000), 2_000_000_000_000)
     }
 
     /// Only `Int.min` is the documented sentinel. A real, non-sentinel negative value is NOT a
     /// sentinel and must survive unchanged — the guard must not silently zero legitimate data.
     func testNonSentinelNegativePassesThrough() {
-        XCTAssertEqual(BandwidthSampler.sanitizeSimpleValue(-1), -1)
+        XCTAssertEqual(IOReportNaming.sanitizeSimpleValue(-1), -1)
         // Int.min + 1 is the largest-in-magnitude negative that is NOT the sentinel.
-        XCTAssertEqual(BandwidthSampler.sanitizeSimpleValue(Int.min + 1), Int.min + 1)
+        XCTAssertEqual(IOReportNaming.sanitizeSimpleValue(Int.min + 1), Int.min + 1)
     }
 
     // MARK: - The sentinel no longer corrupts a per-bus sum
@@ -53,7 +53,7 @@ final class BandwidthSimpleSentinelTests: XCTestCase {
     /// shape and the M-series `sampleAMCStatsSimple` per-requestor accumulation shape, in miniature.
     func testSentinelLaneDoesNotCorruptSum() {
         let lanes = [2_000_000_000, 3_000_000_000, Int.min]   // two live lanes + one unpopulated
-        let totalBytes = lanes.reduce(0.0) { $0 + Double(BandwidthSampler.sanitizeSimpleValue($1)) }
+        let totalBytes = lanes.reduce(0.0) { $0 + Double(IOReportNaming.sanitizeSimpleValue($1)) }
         XCTAssertEqual(totalBytes, 5_000_000_000, accuracy: 1e-6,
                        "the unpopulated lane must contribute 0, leaving only the two live lanes")
     }

--- a/Tests/SiliconScopeCoreTests/PowerSamplerSimpleSentinelTests.swift
+++ b/Tests/SiliconScopeCoreTests/PowerSamplerSimpleSentinelTests.swift
@@ -1,0 +1,74 @@
+//
+//  File:      PowerSamplerSimpleSentinelTests.swift
+//  Created:   2026-08-10
+//  Updated:   2026-08-10
+//  Developer: Yurii Chukhlib
+//  Overview:  Unit tests for `PowerSampler.simpleWatts` — the per-rail energy → watts conversion
+//             that strips the IOReport "Simple" `INT64_MIN` "unpopulated" sentinel before the mJ → W
+//             math. The same sentinel `BandwidthSimpleSentinelTests` pins for bandwidth, pinned here
+//             for power so one dead rail can no longer swamp a whole domain's wattage.
+//  Notes:     No hardware: `simpleWatts` is a pure (Int + TimeInterval → Double) seam extracted from
+//             `sample()` for exactly this. The sentinel is `Int64.min` (`Int.min` on the 64-bit
+//             target) — the value `channelDump()` labels "not populated, raw INT64_MIN". Pre-fix it
+//             was read straight into `Double(...)` ≈ -9.2e18 mJ and dominated the per-domain sum; the
+//             shared `IOReportNaming.sanitizeSimpleValue` now strips it before the division.
+//
+import XCTest
+@testable import SiliconScopeCore
+
+final class PowerSamplerSimpleSentinelTests: XCTestCase {
+
+    // MARK: - INT64_MIN "unpopulated" sentinel → 0 W
+
+    /// An unpopulated energy rail (the `Int.min` sentinel) must read as 0 W, not as a real energy
+    /// delta. Before the guard it was divided straight into a huge-negative wattage that dominated
+    /// whichever domain (CPU/GPU/ANE/DRAM) the dead rail happened to land in.
+    func testSentinelRailReadsZeroWatts() {
+        XCTAssertEqual(PowerSampler.simpleWatts(raw: .min, seconds: 0.2), 0,
+                       "INT64_MIN / Int.min 'unpopulated' rail reads as 0 W, not a real energy delta")
+    }
+
+    // MARK: - Real readings convert correctly (mJ / s / 1000 = W)
+
+    func testRealRailConvertsMillijoulesToWatts() {
+        // 8000 mJ over 0.2 s = 40 W (a realistic GPU rail under load).
+        XCTAssertEqual(PowerSampler.simpleWatts(raw: 8_000, seconds: 0.2), 40, accuracy: 1e-9)
+        // 1200 mJ over 0.3 s = 4 W.
+        XCTAssertEqual(PowerSampler.simpleWatts(raw: 1_200, seconds: 0.3), 4, accuracy: 1e-9)
+    }
+
+    /// Only `Int.min` is the documented sentinel. A real, non-sentinel negative value is NOT a
+    /// sentinel and must convert unchanged — the guard must not silently zero legitimate data (a
+    /// genuinely negative delta would itself be suspect, but that is a question for the caller, not
+    /// a value the sentinel guard should hide).
+    func testNonSentinelNegativeConvertsUnchanged() {
+        XCTAssertEqual(PowerSampler.simpleWatts(raw: -1, seconds: 0.2),
+                       Double(-1) / 0.2 / 1000.0, accuracy: 1e-9)
+        XCTAssertEqual(PowerSampler.simpleWatts(raw: Int.min + 1, seconds: 0.2),
+                       Double(Int.min + 1) / 0.2 / 1000.0, accuracy: 1e3)
+    }
+
+    // MARK: - The sentinel no longer corrupts a per-domain sum
+
+    /// Two live rails plus one unpopulated rail (the sentinel). Pre-fix, the unguarded
+    /// `Double(Int.min)` ≈ -9.2e18 dominated the sum; post-fix the dead rail contributes 0 W, so the
+    /// domain total is just the two live rails. This is the `sample()` per-domain accumulation shape
+    /// (e.g. GPU0 + GPU SRAM0 + an unpopulated sibling) in miniature.
+    func testSentinelRailDoesNotCorruptDomainSum() {
+        let rails = [8_000, 4_000, Int.min]   // two live rails + one unpopulated, over 0.2 s
+        let watts = rails.reduce(0.0) { $0 + PowerSampler.simpleWatts(raw: $1, seconds: 0.2) }
+        // 8000 mJ + 4000 mJ over 0.2 s = 60 W; the unpopulated rail adds nothing.
+        XCTAssertEqual(watts, 60, accuracy: 1e-6,
+                       "the unpopulated rail must contribute 0 W, leaving only the two live rails")
+    }
+
+    /// Documents the exact corruption the guard prevents: the same rails summed *without* the guard.
+    /// It is a huge-negative, overflow-scale wattage — what a user would have seen before this fix.
+    /// Kept as a regression witness so the failure mode is self-explanatory if the guard is removed.
+    func testDocumentsThePreFixCorruption() {
+        let rails = [8_000, 4_000, Int.min]
+        let unguarded = rails.reduce(0.0) { $0 + Double($1) / 0.2 / 1000.0 }
+        XCTAssertLessThan(unguarded, -1e16,
+                          "pre-fix: Double(Int.min) dominates the sum — an overflow-scale wattage, the bug this guard fixes")
+    }
+}


### PR DESCRIPTION
## Summary
`PowerSampler.sample()` read each IOReport "Simple" energy channel straight into `Double(IOReportSimpleGetIntegerValue(...))` with no sentinel guard, so an unpopulated rail — which IOReport fills with `INT64_MIN` — became `Double(Int.min)` ≈ -9.2e18 mJ and dominated whichever power domain (CPU / GPU / ANE / DRAM) the dead rail happened to land in. That is the same IOReport convention the bandwidth sampler already strips (`9c68291`), corrupting the per-domain wattage the same way it once corrupted the per-bus GB/s. The maintainer note on `BandwidthSampler.sanitizeSimpleValue` flagged this as a separate PR ("promote/reuse this helper rather than re-deriving `raw == Int.min ? 0`"); this is that PR.

## What this PR does
- Promotes the `INT64_MIN`-stripping rule to `IOReportNaming.sanitizeSimpleValue`, the shared IOReport helper namespace the bandwidth and power samplers already use, so the guard has one definition instead of being copied per sampler.
- Points `BandwidthSampler`'s two call sites (and `BandwidthSimpleSentinelTests`) at the single shared definition — a pure relocation, behaviour identical to `9c68291`.
- Routes `PowerSampler`'s per-rail mJ → W conversion through the shared guard, via a small pure `simpleWatts(raw:seconds:)` seam so the `Int.min` boundary is unit-testable without an IOReport subscription.

## Test plan
- [x] `xcrun swift build` — clean
- [x] `xcrun swift test` — 216/216 pass (5 new: `PowerSamplerSimpleSentinelTests` — sentinel rail reads 0 W, real mJ converts to W, a non-sentinel negative passes through, a dead rail no longer swamps a domain sum, plus a pre-fix-corruption witness)
- Not verified on hardware: an actually-unpopulated Energy Model rail is the real trigger, and I can't reproduce that headlessly. The pure seam lets the `Int.min` boundary be exercised deterministically without one, the same way `BandwidthSimpleSentinelTests` does for bandwidth.