### PR TITLE
fix(battery): a battery with unreadable health is not a normal battery

### DIFF
--- a/Sources/SiliconScopeCore/Battery.swift
+++ b/Sources/SiliconScopeCore/Battery.swift
@@ -1,7 +1,7 @@
 //
 //  File:      Battery.swift
 //  Created:   2026-06-08
-//  Updated:   2026-07-15
+//  Updated:   2026-08-10
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Battery charge/charging state (IOPowerSources) plus health/cycles/condition
 //             read sudolessly from the AppleSmartBattery IORegistry entry. Stateless.
@@ -114,9 +114,17 @@ public final class BatterySampler {
     }
 
     /// Condition string from health + permanent-failure flag (matches macOS wording).
+    ///
+    /// `healthPercent == 0` is the "capacities unreadable" sentinel of `healthPercent` (a guard
+    /// failure), NOT a measurement of a healthy battery, so it must not be asserted "Normal" — a
+    /// positive claim the data does not support. It must also match the empty condition `sample()`
+    /// emits when the AppleSmartBattery read fails outright: the two "health unknown" paths agreeing
+    /// is what keeps a partially-read battery (non-nil props missing DesignCapacity) from showing a
+    /// contradictory "0 % — Normal". A permanent failure still wins regardless of the health number.
     static func condition(healthPercent: Double, permanentFailure: Bool) -> String {
-        (permanentFailure || (healthPercent > 0 && healthPercent < 80))
-            ? "Service Recommended" : "Normal"
+        if permanentFailure { return "Service Recommended" }
+        if healthPercent <= 0 { return "" }   // unknown — capacities not read; don't claim a condition
+        return healthPercent < 80 ? "Service Recommended" : "Normal"
     }
 
     /// Copies the AppleSmartBattery IORegistry properties, or nil on desktops / failure.

--- a/Tests/SiliconScopeCoreTests/BatteryHealthTests.swift
+++ b/Tests/SiliconScopeCoreTests/BatteryHealthTests.swift
@@ -1,7 +1,7 @@
 //
 //  File:      BatteryHealthTests.swift
 //  Created:   2026-06-20
-//  Updated:   2026-06-20
+//  Updated:   2026-08-10
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Pure tests for battery health % (full-charge / design capacity, clamped) and
 //             the derived condition string. Capacities come from AppleSmartBattery at
@@ -35,6 +35,18 @@ final class BatteryHealthTests: XCTestCase {
                        "Service Recommended")
         // A permanent failure flag forces Service Recommended even at high health.
         XCTAssertEqual(BatterySampler.condition(healthPercent: 95, permanentFailure: true),
+                       "Service Recommended")
+    }
+
+    /// health == 0 is the "capacities unreadable" sentinel of `healthPercent` (see
+    /// `testHealthZeroWhenCapacitiesUnknown`), not a measurement of a healthy battery. Asserting
+    /// "Normal" there would be a positive claim the data does not support, and would disagree with
+    /// the empty condition `sample()` emits when the AppleSmartBattery read fails outright (the two
+    /// "health unknown" paths must agree). Unknown health ⇒ no condition, matching that path.
+    func testUnknownHealthIsNotAssertedNormal() {
+        XCTAssertEqual(BatterySampler.condition(healthPercent: 0, permanentFailure: false), "")
+        // A permanent failure still wins even when the health number is unknown.
+        XCTAssertEqual(BatterySampler.condition(healthPercent: 0, permanentFailure: true),
                        "Service Recommended")
     }
 }


### PR DESCRIPTION
## Summary
`BatterySampler.condition()` returned `"Normal"` when `healthPercent` was `0`, but `0` is not a measurement of a healthy cell — it is the "capacities unreadable" sentinel that `healthPercent` returns when its guard fails (`designCapacity > 0, maxCapacity > 0`). That made the two "health unknown" code paths in `sample()` disagree: a failed `smartBatteryProperties()` read left `condition` at `""` (the field default), while a *successful* read whose dict was missing `DesignCapacity` (so `healthPercent` guarded to 0) yielded `"Normal"` — so a partially-read battery could show a contradictory `0% — Normal`.

## What this PR does
- Treats the `healthPercent <= 0` sentinel in `condition()` the same way the failed-read path already does: unknown health produces no condition (`""`), not a positive `"Normal"` claim the data does not support.
- Keeps a `permanentFailure` flag forcing `"Service Recommended"` regardless of the health number (a genuinely failed battery is still flagged).

## Test plan
- [x] `xcrun swift build` — clean
- [x] `xcrun swift test` — 212/212 pass (1 new: `testUnknownHealthIsNotAssertedNormal` pins `condition(healthPercent: 0, permanentFailure: false) == ""`, was `"Normal"`; also confirms a permanent failure still wins at health 0). The existing threshold tests (94/80/79/95) are unchanged.
- Not verified on hardware: the real trigger is an AppleSmartBattery dict that is non-nil but missing `DesignCapacity`, which I cannot reproduce headlessly. The `healthPercent == 0` sentinel it reduces to is the pure boundary this PR pins, and it is reached deterministically through `healthPercent`'s guard (already locked by `testHealthZeroWhenCapacitiesUnknown`).