### PR TITLE
fix(bandwidth): use sole AMCC histogram as total

### DIFF
--- a/Sources/SiliconScopeCore/BandwidthSample.swift
+++ b/Sources/SiliconScopeCore/BandwidthSample.swift
@@ -1,7 +1,7 @@
 //
 //  File:      BandwidthSample.swift
 //  Created:   2026-06-08
-//  Updated:   2026-07-16
+//  Updated:   2026-08-15
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Value type holding one unified-memory bandwidth reading (GB/s), split
 //             by requestor. The headline signal for local-LLM throughput (token
@@ -23,18 +23,16 @@ public struct BandwidthSample: Sendable, Equatable, Codable {
     public var gpuGBs: Double = 0
     public var mediaGBs: Double = 0    // Media Engine: video codec / ProRes traffic
     public var otherGBs: Double = 0    // display, storage, ISP, PCIe, ...
-    /// Measured total when the per-requestor split isn't available (A18/MacBook Neo: IOReport
-    /// exposes only PMP "DRAM BW" by frequency state, not by requestor). nil → fall back to the sum.
+    /// Measured total when the per-requestor split is unavailable (A18 "DRAM BW", or the sole
+    /// PMP0/AMCC histogram on M3 Max/macOS 27). nil → fall back to the classified requestor sum.
     public var measuredTotalGBs: Double? = nil
 
     /// True when this sample came from `BandwidthSampler`'s PMP "DCS BW" residency-histogram
     /// fallback (used when the classic "AMC Stats" byte-delta subscription is unavailable — see
-    /// BandwidthSampler's file header and github.com/kennss/SiliconScope#14/#29). That path's
-    /// per-requestor values are clamped at a labeled "32GB/s" top bucket and `totalGBs` is a sum
-    /// across many requestor channels rather than one authoritative chip-wide counter, so figures
-    /// can understate true peak bandwidth and should not be compared precisely against a chip's
-    /// spec ceiling. UI that reasons about "% of ceiling" should treat this as an honest estimate,
-    /// not a measurement — same "label the estimate" philosophy as the ANE usage number.
+    /// BandwidthSampler's file header and github.com/kennss/SiliconScope#14/#29/#46). M4/M5
+    /// expose per-requestor histograms whose labeled 32GB/s top bucket can clamp real traffic;
+    /// M3 Max/macOS 27 exposes one wider AMCC aggregate histogram instead. Both are estimates,
+    /// not precise byte-delta measurements, so UI that reasons about a chip's ceiling must say so.
     public var isEstimated: Bool = false
 
     public init() {}

--- a/Sources/SiliconScopeCore/BandwidthSampler.swift
+++ b/Sources/SiliconScopeCore/BandwidthSampler.swift
@@ -1,7 +1,7 @@
 //
 //  File:      BandwidthSampler.swift
 //  Created:   2026-06-08
-//  Updated:   2026-08-10
+//  Updated:   2026-08-15
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Reads unified-memory bandwidth (GB/s) sudolessly. Three read strategies,
 //             tried in order at init and locked in for the sampler's lifetime:
@@ -9,16 +9,13 @@
 //                 by DVFS frequency state (no per-requestor split).
 //             (2) M-series, classic: IOReport "AMC Stats" group, "Perf Counters" subgroup,
 //                 Simple format "<unit> DCS RD/WR" byte-delta channels, per requestor.
-//             (3) M-series, PMP histogram fallback: on chip/OS combinations where the
-//                 "AMC Stats" subscription itself fails outright (confirmed on an Apple M4
-//                 Max, macOS 26.5.2 — IOReportCopyChannelsInGroup finds ~190 channels but
-//                 IOReportCreateSubscription returns nil for the group), the same
-//                 per-requestor byte counters live instead under IOReport "PMP" (renamed
-//                 "PMP0" on M5 Max/macOS 26.5.2, github.com/kennss/SiliconScope#30 — resolved
-//                 across the "PMP"/"PMP0"/"PMP1" family), subgroup "DCS BW", as State-format
-//                 residency histograms named "1GB/s".."32GB/s" per requestor (e.g. "EACC0
-//                 RD+WR" / "MACC0 RD+WR", "AGX RD+WR") — the same residency-weighting idiom
-//                 CPUSampler already uses for DVFS frequency, applied to bandwidth buckets.
+//             (3) M-series, PMP histogram fallback: when "AMC Stats" cannot be subscribed,
+//                 bandwidth moves to the "PMP"/"PMP0"/"PMP1" family, subgroup "DCS BW",
+//                 as State-format residency histograms. M4/M5 expose "1GB/s".."32GB/s"
+//                 histograms per requestor (e.g. "EACC0 RD+WR" / "MACC0 RD+WR", "AGX
+//                 RD+WR"). M3 Max on macOS 27 build 26A5388g exposes only one wider
+//                 chip-wide "AMCC RD+WR" histogram under PMP0 (#46); that aggregate supplies
+//                 measuredTotalGBs while the unavailable CPU/GPU/Media split stays zero.
 //  Notes:     Requestor map (classic path): ECPU/PCPU* -> CPU, GFX -> GPU,
 //             ISP/VENC/VDEC/PRORES/CODEC/JPEG -> Media, "DCS" is the chip-wide aggregate
 //             (= total); other = total - the above. MSR is intentionally NOT media (matches
@@ -27,13 +24,12 @@
 //             core-id token (e.g. "DIE0 ECPU0") on top of the bare unit name, per
 //             github.com/kennss/SiliconScope#14 (Apple restructured "AMC Stats" channel
 //             names on macOS 27 beta / M3 Max to add this prefix and split RD/WR channels).
-//             The PMP-histogram fallback path (3) has no authoritative chip-wide total
-//             channel, so `totalGBs` there is the sum of the classified buckets (see
-//             `BandwidthSample.totalGBs`); its top bucket ("32GB/s") is very likely a
-//             saturating/clamped bin, not a literal ceiling — observed residency spikes
-//             there under heavy GPU load — so the weighted average is a real, directionally
-//             correct GB/s figure but can understate true peak bandwidth. Honest limitation,
-//             not hidden: same "label the estimate" philosophy as the ANE usage number.
+//             The PMP-histogram fallback has two observed shapes. Per-requestor M4/M5
+//             channels have no trustworthy chip-wide total, so `totalGBs` sums their
+//             classified buckets; the labeled 32GB/s top bucket can clamp real traffic.
+//             M3 Max/macOS 27 instead exposes only AMCC, a wider chip-wide aggregate, so
+//             that value is used only when no additive requestor channels exist. Every
+//             histogram reading remains an estimate, surfaced via `isEstimated`.
 //             `channelDump()` (raw inventory dump, both paths) exists to diagnose chip/OS
 //             combinations neither path handles yet.
 //
@@ -279,17 +275,31 @@ public final class BandwidthSampler {
         return .other   // ANE(L0/L1), ANS, ATC0-3, DISPEXT0-3, DISPINT, MSR0/1, …
     }
 
-    /// Requestors excluded from the PMP-histogram per-requestor sum. `AMCC` is the
-    /// memory-controller aggregate whose histogram buckets start at "32GB/s" (32..224), so its
-    /// residency-weighted average never reads below ~32 GB/s — it inflates other/total even at
-    /// idle and is not an additive per-requestor lane (measured on M5 Max, #30). Note `AMCC`
-    /// (prefix) is distinct from the M5 CPU cluster `MACC*`, which is NOT excluded.
-    static func isPMPHistogramExcluded(_ requestor: String) -> Bool {
+    /// True for the PMP histogram's `AMCC` memory-controller aggregate. It is not an additive
+    /// requestor lane: M5 exposes it alongside CPU/GPU/etc. channels with a permanent ~32 GB/s
+    /// floor, while M3 Max/macOS 27 exposes it as the only `DCS BW` channel and its only usable
+    /// total. `samplePMPHistogram` decides which role applies from the rest of the inventory.
+    /// `AMCC` (prefix) is distinct from the M5 CPU cluster `MACC*`.
+    static func isPMPHistogramAggregate(_ requestor: String) -> Bool {
         requestor.uppercased().hasPrefix("AMCC")
+    }
+
+    /// Use AMCC as the measured total only for the aggregate-only PMP layout observed on M3
+    /// Max/macOS 27. If any additive requestor lane exists, preserve the M4/M5 behavior: ignore
+    /// AMCC and sum the classified lanes. More than one aggregate is ambiguous, so report no
+    /// aggregate total rather than guessing how multiple memory-controller channels compose.
+    static func pmpMeasuredTotalGBs(aggregateGBs: Double?,
+                                    aggregateChannelCount: Int,
+                                    perRequestorChannelCount: Int) -> Double? {
+        guard aggregateChannelCount == 1, perRequestorChannelCount == 0 else { return nil }
+        return aggregateGBs
     }
 
     private static func samplePMPHistogram(delta: CFDictionary) -> BandwidthSample {
         var cpu = 0.0, gpu = 0.0, media = 0.0, other = 0.0
+        var aggregateGBs: Double?
+        var aggregateChannelCount = 0
+        var perRequestorChannelCount = 0
 
         IOReportIterate(delta) { channel in
             guard IOReportChannelGetFormat(channel) == kKtopIOReportFormatState,
@@ -304,9 +314,6 @@ public final class BandwidthSampler {
             // breakdown channels would double-count if also summed in.
             guard name.uppercased().hasSuffix(" RD+WR") else { return Int32(kKtopIOReportIterOk) }
             let requestor = String(name.dropLast(6))   // strip " RD+WR"
-            // Skip the AMCC memory-controller aggregate — its buckets start at 32GB/s so it
-            // never reads below ~32 and inflates other/total (M5 Max, #30). Not additive.
-            if Self.isPMPHistogramExcluded(requestor) { return Int32(kKtopIOReportIterOk) }
 
             let stateCount = Int(IOReportStateGetCount(channel))
             var buckets: [(gbs: Double, residency: UInt64)] = []
@@ -318,6 +325,13 @@ public final class BandwidthSampler {
                 buckets.append((gbs, IOReportStateGetResidency(channel, Int32(i))))
             }
             let value = Self.weightedAverageGBs(buckets)
+
+            if Self.isPMPHistogramAggregate(requestor) {
+                aggregateGBs = value
+                aggregateChannelCount += 1
+                return Int32(kKtopIOReportIterOk)
+            }
+            perRequestorChannelCount += 1
 
             switch Self.classifyPMPHistogramRequestor(requestor) {
             case .cpu:            cpu += value
@@ -333,9 +347,12 @@ public final class BandwidthSampler {
         result.gpuGBs = gpu
         result.mediaGBs = media
         result.otherGBs = other
+        result.measuredTotalGBs = Self.pmpMeasuredTotalGBs(
+            aggregateGBs: aggregateGBs,
+            aggregateChannelCount: aggregateChannelCount,
+            perRequestorChannelCount: perRequestorChannelCount
+        )
         result.isEstimated = true
-        // No authoritative chip-wide total in this path — BandwidthSample.totalGBs falls back
-        // to summing cpu+gpu+media+other, which is exactly what we want here.
         return result
     }
 

--- a/Tests/SiliconScopeCoreTests/BandwidthPMPHistogramTests.swift
+++ b/Tests/SiliconScopeCoreTests/BandwidthPMPHistogramTests.swift
@@ -1,16 +1,14 @@
 //
 //  File:      BandwidthPMPHistogramTests.swift
 //  Created:   2026-07-15
-//  Updated:   2026-07-15
+//  Updated:   2026-08-15
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Unit tests for the PMP "DCS BW" histogram fallback path in BandwidthSampler —
-//             the residency-weighted-average math, the "NGB/s" state-name parser, and the
-//             PMP-specific requestor → bucket map (distinct spellings from the classic "AMC
-//             Stats" map: "EACC*"/"PACC*"/"AGX" rather than "ECPU"/"PCPU"/"GFX").
-//  Notes:     No hardware: these are pure functions over explicit (name, residency) inputs,
-//             fixtures taken from this project's own M4 Max / macOS 26.5.2 characterization
-//             (see docs/ioreport-channels.md) where the classic "AMC Stats" subscription fails
-//             outright and this histogram is the only source of real bandwidth data.
+//             the residency-weighted-average math, the "NGB/s" state-name parser, requestor
+//             classification, and aggregate-only AMCC fallback.
+//  Notes:     No hardware: these are pure functions over explicit inputs. Fixtures come from
+//             M4/M5 Max macOS 26.5.2 per-requestor histograms and the M3 Max macOS 27
+//             aggregate-only histogram documented in docs/ioreport-channels.md.
 //
 import XCTest
 @testable import SiliconScopeCore
@@ -92,7 +90,7 @@ final class BandwidthPMPHistogramTests: XCTestCase {
         for other in ["ANE0", "ANS", "ATC0", "ATC3", "DISPEXT0", "DISPINT", "MSR0", "MSR1", "AMCC"] {
             XCTAssertEqual(BandwidthSampler.classifyPMPHistogramRequestor(other), .other, other)
         }
-        // Never .total — this path has no chip-wide aggregate channel.
+        // The per-requestor classifier never returns .total; AMCC is handled separately.
         XCTAssertNotEqual(BandwidthSampler.classifyPMPHistogramRequestor("EACC0"), .total)
     }
 
@@ -114,16 +112,47 @@ final class BandwidthPMPHistogramTests: XCTestCase {
         }
     }
 
-    // MARK: - AMCC exclusion from the PMP-histogram sum (github.com/kennss/SiliconScope#30)
+    // MARK: - AMCC aggregate handling (github.com/kennss/SiliconScope#30/#46)
 
-    func testPMPHistogramExcludesAMCCNotMACC() {
-        // AMCC = memory-controller aggregate (buckets start at 32GB/s) → excluded from the sum.
-        XCTAssertTrue(BandwidthSampler.isPMPHistogramExcluded("AMCC"))
-        XCTAssertTrue(BandwidthSampler.isPMPHistogramExcluded("AMCC0"))
-        // The M5 CPU cluster "MACC*" must NOT be caught by the AMCC exclusion (prefix distinct).
-        XCTAssertFalse(BandwidthSampler.isPMPHistogramExcluded("MACC0"))
-        XCTAssertFalse(BandwidthSampler.isPMPHistogramExcluded("MACC1"))
-        XCTAssertFalse(BandwidthSampler.isPMPHistogramExcluded("AGX"))
-        XCTAssertFalse(BandwidthSampler.isPMPHistogramExcluded("PACC"))
+    func testPMPHistogramRecognizesAMCCAggregateNotMACC() {
+        XCTAssertTrue(BandwidthSampler.isPMPHistogramAggregate("AMCC"))
+        XCTAssertTrue(BandwidthSampler.isPMPHistogramAggregate("AMCC0"))
+        // The M5 CPU cluster "MACC*" must not be mistaken for the AMCC aggregate.
+        XCTAssertFalse(BandwidthSampler.isPMPHistogramAggregate("MACC0"))
+        XCTAssertFalse(BandwidthSampler.isPMPHistogramAggregate("MACC1"))
+        XCTAssertFalse(BandwidthSampler.isPMPHistogramAggregate("AGX"))
+        XCTAssertFalse(BandwidthSampler.isPMPHistogramAggregate("PACC"))
+    }
+
+    func testPMPHistogramUsesSoleAMCCAsMeasuredTotal() {
+        // Live M3 Max/macOS 27 fixture: PMP0/DCS BW exposes only AMCC while GPU is loaded.
+        let total = BandwidthSampler.pmpMeasuredTotalGBs(
+            aggregateGBs: 278.695,
+            aggregateChannelCount: 1,
+            perRequestorChannelCount: 0
+        )
+        XCTAssertEqual(total ?? -1, 278.695, accuracy: 0.001)
+    }
+
+    func testPMPHistogramIgnoresAMCCBesidePerRequestorChannels() {
+        // M5's AMCC has an idle floor and must not be added to its real requestor lanes.
+        XCTAssertNil(BandwidthSampler.pmpMeasuredTotalGBs(
+            aggregateGBs: 40.1,
+            aggregateChannelCount: 1,
+            perRequestorChannelCount: 20
+        ))
+    }
+
+    func testPMPHistogramRejectsMissingOrAmbiguousAggregate() {
+        XCTAssertNil(BandwidthSampler.pmpMeasuredTotalGBs(
+            aggregateGBs: nil,
+            aggregateChannelCount: 0,
+            perRequestorChannelCount: 0
+        ))
+        XCTAssertNil(BandwidthSampler.pmpMeasuredTotalGBs(
+            aggregateGBs: 200,
+            aggregateChannelCount: 2,
+            perRequestorChannelCount: 0
+        ))
     }
 }

--- a/docs/ioreport-channels.md
+++ b/docs/ioreport-channels.md
@@ -54,22 +54,34 @@ chip/OS combination where this entire group fails to subscribe.
 
 `GB/s = (bytes / interval_s) / 1e9`
 
-### macOS 27 beta / M3 Max — channel names restructured (unverified fix, documented upstream)
+### macOS 27 / M3 Max — `AMC Stats` became unsubscribable; `PMP0` now exposes total only
 
-Not independently re-verified by this project — see
-[github.com/kennss/SiliconScope#14](https://github.com/kennss/SiliconScope/issues/14) (filed by
-the maintainer) for the full, hardware-verified writeup. Summary: on macOS 27.0.0 beta, an M3
-Max still exposes the `AMC Stats`/`Perf Counters` group and its channels subscribe fine, but
-Apple restructured the channel *names* three ways: a leading `DIE0` chip-id/per-core token
-(`ECPU DCS RD` → `DIE0 ECPU0 DCS RD`), the combined `RD/WR` suffix split into separate channels
-with several shapes (`RD/WR`, `RD/WR/RDWR`, `RD/WR + RD/WR`), and ~19 new unclassified requestor
-families (`AVE0/1`, `SCODEC`, `SEP`, `SIO`, `ATC0-3`, `MSR0/1`, `PCIEGE`, `GFXA/B/C`,
-`EXT_DISP0-3`). Separately, the surviving channels were observed reading the `INT64_MIN`
-sentinel instead of real bytes — an open question, not solved by this project. `classify()` in
-`BandwidthSampler.swift` now tolerates the `DIE0` prefix and the additional RD/WR suffix shapes
-(see its `contains(_:unitPrefix:)` and `hasReadWriteToken`/`stripReadWriteSuffix` helpers), which
-should address the naming/classification half of #14 — but this project has no macOS 27 hardware
-to confirm the `INT64_MIN` half against.
+Two macOS 27 layouts have been observed on the same M3 Max generation. The early beta captured in
+[issue #14](https://github.com/kennss/SiliconScope/issues/14) still allowed an `AMC Stats`
+subscription, but its renamed `DIE0`-prefixed Simple channels returned `INT64_MIN` rather than byte
+deltas. The requestor-name fixes remain useful for any build where those channels populate, but
+they could not solve the missing values.
+
+On macOS 27.0 build **26A5388g** (Apple M3 Max, Mac15,9;
+[issue #46](https://github.com/kennss/SiliconScope/issues/46), verified 2026-08-15), the layout
+changed again:
+
+- `IOReportCopyChannelsInGroup("AMC Stats", ...)` still finds the group, but
+  `IOReportCreateSubscription` now returns `nil`.
+- The subscribable fallback is `PMP0` / `DCS BW`, State format.
+- That subgroup exposes exactly one combined requestor: `AMCC RD+WR`. Under a sustained 96–98%
+  GPU workload, its residency-weighted value was **278.695 GB/s**, with non-zero buckets from
+  64 through 384 GB/s. At lower load, live samples moved to 32–43 GB/s and the raw histogram read
+  40.788 GB/s across 32–192 GB/s buckets. It tracks load, but its 32 GB/s lowest bucket makes the
+  result coarse and gives it a non-zero floor.
+
+This is not the M5 layout below. On M5, AMCC sits beside about twenty additive requestor histograms,
+so adding its aggregate would double-count traffic as well as importing that floor. On this
+M3/macOS 27 layout, AMCC is the entire available signal; excluding it leaves an empty sample and
+guarantees 0 GB/s. `BandwidthSampler` therefore uses AMCC as `measuredTotalGBs` only when it is the
+sole aggregate and no per-requestor channels exist. CPU/GPU/Media remain zero because this layout
+does not expose a defensible split, and `isEstimated` remains true because the source is a coarse
+residency histogram rather than byte deltas.
 
 ### M4 Max / macOS 26.5.2 — "AMC Stats" subscription fails outright; data relocated to `PMP`/"DCS BW"
 
@@ -97,16 +109,13 @@ not `ECPU`/`PCPU`), `AGX` (GPU, not `GFX`), `ISP0`/`JPEG0`/`PRORES1`/`SCODEC0`/`
 fails, and only reads the combined `<requestor> RD+WR` channel per requestor (the separate
 RD-only/WR-only breakdown channels are not also summed in, to avoid double-counting).
 
-**Known limitation, observed and not solved here:** the top bucket (`"32GB/s"`) is very likely a
-saturating/clamped bin rather than a literal ceiling — under a sustained heavy-GPU workload, the
-`AGX RD+WR` channel showed a real residency spike concentrated in that top bucket (tens of ticks
-out of a few hundred), and the always-on `AMCC` requestor (folded into `other`) was observed
-reading *100% of its residency* in the top bucket continuously, even near-idle — suggesting
-`AMCC`'s counter may not behave like the others. The weighted average is real, non-fabricated,
-and moves correctly with load, but can understate true peak bandwidth for requestors that
-saturate past 32 GB/s, and `other`/`total` may run persistently elevated because of `AMCC`. Not
-fixed in this change; flagged for whoever picks up more precise interpretation of this histogram
-next.
+**Known limitation:** each M4/M5 per-requestor histogram tops out at a labeled `"32GB/s"` bucket
+that behaves like a saturating bin. Under a sustained heavy-GPU workload, `AGX RD+WR` accumulated
+real residency in that top bucket, so the weighted value moves with load but can understate the
+true peak. `AMCC` is a separate, non-additive memory-controller aggregate. On M5 its buckets start
+at 32 GB/s and it remains elevated near idle, so `BandwidthSampler` excludes it whenever additive
+CPU/GPU/Media/other requestor channels are present. The aggregate-only M3/macOS 27 case above is
+the narrow exception.
 
 **Follow-up finding, confirming the above against this chip's real spec ceiling:** this M4 Max
 (40-core GPU) has a theoretical unified-memory-bandwidth ceiling of 546 GB/s


### PR DESCRIPTION
## Summary

Fixes #46.

On M3 Max with macOS 27 build 26A5388g, `AMC Stats` is no longer subscribable and `PMP0 / DCS BW` exposes only one combined channel: `AMCC RD+WR`. SiliconScope currently excludes AMCC unconditionally, leaving an empty sample and reporting 0 GB/s under real load.

This change uses AMCC as `measuredTotalGBs` only for that aggregate-only layout.

## Why the condition is narrow

AMCC was excluded for a good reason in #30. On M5 it sits beside the additive CPU/GPU/Media/other requestor histograms, has a 32 GB/s floor, and would double-count traffic if included in their sum.

The sampler now keeps AMCC separate and uses it only when:

- exactly one AMCC aggregate is present; and
- no per-requestor `RD+WR` channels are present.

If requestor channels exist, the M4/M5 behavior is unchanged. If the inventory is ambiguous, the sampler still returns no aggregate rather than guessing. CPU/GPU/Media remain zero on the M3 layout because IOReport does not expose a defensible split, and `isEstimated` remains true.

## Verification

Hardware: Apple M3 Max, Mac15,9, macOS 27.0 build 26A5388g.

- Before: total bandwidth stayed at 0 GB/s with GPU usage at 85–100%.
- Raw `AMCC RD+WR`: 278.695 GB/s at 96–98% GPU load; 40.788 GB/s at lower load. The histogram moves with load but has a coarse 32 GB/s lowest bucket.
- After: the live probe reported 32–43 GB/s at low/moderate load instead of zero.
- `xcrun swift build` — passed.
- `xcrun swift test -q` — 220 tests passed.

The tests cover both observed layouts: sole AMCC becomes the measured total, while AMCC beside M5-style requestor channels remains excluded. `docs/ioreport-channels.md` records the exact OS build, channel inventory, measured values, and precision limit.