### PR TITLE
feat(runtime): detect mlx-dspark and follow its --port to the OpenAI-compatible API

### DIFF
--- a/Sources/SiliconScope/SiliconScopeMonitor.swift
+++ b/Sources/SiliconScope/SiliconScopeMonitor.swift
@@ -1,7 +1,7 @@
 //
 //  File:      SiliconScopeMonitor.swift
 //  Created:   2026-06-08
-//  Updated:   2026-07-16
+//  Updated:   2026-08-16
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Observable view-model that drives the UI. Polls SystemSampler on a
 //             background task ~once per second and publishes the latest snapshot plus
@@ -214,6 +214,7 @@ final class SiliconScopeMonitor {
     private struct ProbeInputs {
         let kind: AIRuntimeKind?
         let ollamaEmbedded: Int?
+        let mlxDSparkEmbedded: Int?
         let ollamaPort: Int
         let lmStudioPort: Int
         let omlxPort: Int
@@ -225,6 +226,7 @@ final class SiliconScopeMonitor {
     private func currentProbeInputs() -> ProbeInputs {
         ProbeInputs(kind: snapshot.aiRuntime.primaryKind,
                     ollamaEmbedded: snapshot.aiRuntime.ollamaEmbeddedPort,
+                    mlxDSparkEmbedded: snapshot.aiRuntime.mlxDSparkEmbeddedPort,
                     ollamaPort: Self.port(forKey: "aiRuntimeOllamaPort", default: 11434),
                     lmStudioPort: Self.port(forKey: "aiRuntimeLMStudioPort", default: 1234),
                     omlxPort: Self.port(forKey: "aiRuntimeOmlxPort", default: 8000),
@@ -239,6 +241,7 @@ final class SiliconScopeMonitor {
                 guard let inputs = self?.currentProbeInputs() else { return }
                 let result = await client.probe(primaryKind: inputs.kind,
                                                 ollamaEmbeddedPort: inputs.ollamaEmbedded,
+                                                mlxDSparkEmbeddedPort: inputs.mlxDSparkEmbedded,
                                                 ollamaPort: inputs.ollamaPort,
                                                 lmStudioPort: inputs.lmStudioPort,
                                                 omlxPort: inputs.omlxPort,
@@ -327,6 +330,7 @@ final class SiliconScopeMonitor {
         case .exo:      return 52415
         case .omlx:     return Self.port(forKey: "aiRuntimeOmlxPort", default: 8000)
         case .llamaCpp: return snapshot.aiRuntime.ollamaEmbeddedPort ?? 8080
+        case .mlxDSpark: return snapshot.aiRuntime.mlxDSparkEmbeddedPort ?? 8080
         default:        return Self.port(forKey: "aiRuntimeOllamaPort", default: 11434)
         }
     }

--- a/Sources/SiliconScope/Theme.swift
+++ b/Sources/SiliconScope/Theme.swift
@@ -1,7 +1,7 @@
 //
 //  File:      Theme.swift
 //  Created:   2026-06-08
-//  Updated:   2026-07-27
+//  Updated:   2026-08-16
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Shared visual language and reusable UI atoms (Card, Bar, KV, Sparkline,
 //             PopoverButtonStyle), plus the Layout dimension tokens.
@@ -668,6 +668,7 @@ extension AIRuntimeKind {
         case .lmStudio: return "macwindow"
         case .mlx:      return "cpu.fill"
         case .rapidMLX: return "hare.fill"
+        case .mlxDSpark: return "sparkles"   // speculative decoding — the drafter's "spark"
         case .exo:      return "point.3.connected.trianglepath.dotted"   // distributed cluster
         // On-device apps, not servers: a waveform reads as "audio in, text out", which is what
         // both of these do on the Neural Engine.

--- a/Sources/SiliconScopeCore/AIRuntime.swift
+++ b/Sources/SiliconScopeCore/AIRuntime.swift
@@ -1,11 +1,11 @@
 //
 //  File:      AIRuntime.swift
 //  Created:   2026-06-14
-//  Updated:   2026-08-08
+//  Updated:   2026-08-16
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Catalog + identity for local AI runtimes (Ollama, llama.cpp, LM Studio,
-//             MLX, Rapid-MLX, Jan, GPT4All, vLLM, exo). Pure logic — no syscalls; consumes
-//             the path/args that ProcessSampler already resolved.
+//             MLX, Rapid-MLX, mlx-dspark, Jan, GPT4All, vLLM, exo). Pure logic — no
+//             syscalls; consumes the path/args that ProcessSampler already resolved.
 //  Notes:     proc_name truncates to 15 chars, so the executable PATH is the primary
 //             signal and BUNDLE identity overrides basename — the Ollama runner is a
 //             llama-server child, so basename alone would misclassify it as llama.cpp.
@@ -15,7 +15,7 @@
 import Foundation
 
 public enum AIRuntimeKind: String, Sendable, CaseIterable, Codable {
-    case ollama, llamaCpp, lmStudio, mlx, rapidMLX, jan, gpt4all, vllm, exo, omlx
+    case ollama, llamaCpp, lmStudio, mlx, rapidMLX, mlxDSpark, jan, gpt4all, vllm, exo, omlx
     /// On-device AI **apps** rather than model servers: they run Core ML / WhisperKit inference on
     /// the ANE and never open a port. Detected because the question this card answers is "what is
     /// driving the silicon", and an ASR app driving the Neural Engine is exactly that — indeed the
@@ -33,6 +33,7 @@ public enum AIRuntimeKind: String, Sendable, CaseIterable, Codable {
         case .lmStudio: return "LM Studio"
         case .mlx:      return "MLX"
         case .rapidMLX: return "Rapid-MLX"
+        case .mlxDSpark: return "mlx-dspark"
         case .jan:      return "Jan"
         case .gpt4all:  return "GPT4All"
         case .vllm:     return "vLLM"
@@ -90,6 +91,16 @@ public enum AIRuntimeKind: String, Sendable, CaseIterable, Codable {
         // OpenAI-compatible server is a distinct runtime (port 8000), not bare mlx_lm.
         if base == "rapid-mlx" || p.contains("rapid-mlx") || p.contains("rapid_mlx")
             || a.contains("rapid-mlx") || a.contains("rapid_mlx") { return .rapidMLX }
+        // mlx-dspark (ARahim3/mlx-dspark) — OpenAI-compatible speculative-decoding server for MLX
+        // (`mlx-dspark serve`, default :8080). Also checked before the generic MLX arm. The console
+        // entry point is a shebang Python file, so macOS reports the interpreter and `/bin/mlx-dspark`
+        // lives in argv (mirrors vLLM/exo). Every argv signal is bounded on BOTH sides — leading
+        // `/bin/` / `-m `, trailing space-or-end — so an `mlx-dspark` checkout folder, a user's
+        // --prefix-cache-dir path in an unrelated process's argv, or a sibling helper script
+        // (`mlx-dspark-backup`) can't false-positive on the substring (mirrors the vLLM bound / #38).
+        if base == "mlx-dspark"
+            || a.contains("/bin/mlx-dspark ") || a.hasSuffix("/bin/mlx-dspark")
+            || a.contains("-m mlx_dspark ") || a.hasSuffix("-m mlx_dspark") { return .mlxDSpark }
         if ["llama-server", "llama-cli", "llama-bench"].contains(base) { return .llamaCpp }
         if a.contains("mlx_lm.server") || a.contains("mlx_lm.generate") || a.contains("mlx_lm") { return .mlx }
         if base == "lms" || p.contains("LM Studio") || a.contains("LM Studio") { return .lmStudio }

--- a/Sources/SiliconScopeCore/AIRuntimeSample.swift
+++ b/Sources/SiliconScopeCore/AIRuntimeSample.swift
@@ -1,7 +1,7 @@
 //
 //  File:      AIRuntimeSample.swift
 //  Created:   2026-06-14
-//  Updated:   2026-06-25
+//  Updated:   2026-08-16
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Per-snapshot result of AI-runtime detection: the matched processes plus
 //             grouped roll-ups (RAM / CPU% per kind, primary kind, embedded port).
@@ -71,5 +71,12 @@ public struct AIRuntimeSample: Sendable, Equatable, Codable {
 
     public var ollamaEmbeddedPort: Int? {
         processes.first { $0.kind == .ollama && $0.embeddedPort != nil }?.embeddedPort
+    }
+
+    /// mlx-dspark's console script runs under a python interpreter, so ProcessSampler's argv
+    /// gate admits it and a non-default `--port N` surfaces here for the canonical installs
+    /// (uv tool / pipx / venv) — no settings field needed. nil falls back to the default :8080.
+    public var mlxDSparkEmbeddedPort: Int? {
+        processes.first { $0.kind == .mlxDSpark && $0.embeddedPort != nil }?.embeddedPort
     }
 }

--- a/Sources/SiliconScopeCore/RuntimeAPIClient.swift
+++ b/Sources/SiliconScopeCore/RuntimeAPIClient.swift
@@ -1,13 +1,13 @@
 //
 //  File:      RuntimeAPIClient.swift
 //  Created:   2026-06-14
-//  Updated:   2026-07-02
+//  Updated:   2026-08-16
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Opt-in probes of local AI runtime HTTP APIs, keyed by the detected runtime.
 //             Ollama /api/ps gives the authoritative model size + GPU/CPU split (size_vram
 //             / size); llama.cpp /metrics gives real tokens/sec; LM Studio reports the
-//             loaded model id + quant + context; exo/Rapid-MLX expose an OpenAI-compatible
-//             /v1/models. All sudoless, localhost-only (LocalHTTP).
+//             loaded model id + quant + context; exo/Rapid-MLX/mlx-dspark expose an
+//             OpenAI-compatible /v1/models. All sudoless, localhost-only (LocalHTTP).
 //  Notes:     Every JSON field is optional (version drift tolerant). A non-answer maps to
 //             runningNoServer / apiNotApplicable / unreachable — never a crash. tokens/sec
 //             is left nil unless the runtime actually reports it.
@@ -19,7 +19,7 @@ public struct RuntimeAPIClient: Sendable {
     public init() {}
 
     /// Probes the runtime that feature ① identified as primary.
-    public func probe(primaryKind: AIRuntimeKind?, ollamaEmbeddedPort: Int?,
+    public func probe(primaryKind: AIRuntimeKind?, ollamaEmbeddedPort: Int?, mlxDSparkEmbeddedPort: Int?,
                       ollamaPort: Int, lmStudioPort: Int, omlxPort: Int, omlxApiKey: String) async -> RuntimeAPISample {
         switch primaryKind {
         case .ollama:   return await probeOllama(port: ollamaPort)
@@ -28,6 +28,8 @@ public struct RuntimeAPIClient: Sendable {
         case .rapidMLX: return await probeOpenAI(port: 8000, apiKey: nil, source: .rapidMLX)   // OpenAI-compatible
         case .exo:      return await probeOpenAI(port: 52415, apiKey: nil, source: .exo)       // OpenAI-compatible cluster
         case .omlx:     return await probeOpenAI(port: omlxPort, apiKey: omlxApiKey, source: .omlx)
+        case .mlxDSpark:                              // OpenAI-compatible; its own argv --port wins
+            return await probeOpenAI(port: mlxDSparkEmbeddedPort ?? 8080, apiKey: nil, source: .mlxDSpark)
         case .some:                                   // mlx / jan / gpt4all / vllm
             var s = RuntimeAPISample(); s.status = .runningNoServer; return s
         case .none:

--- a/Sources/SiliconScopeCore/RuntimeAPISample.swift
+++ b/Sources/SiliconScopeCore/RuntimeAPISample.swift
@@ -1,7 +1,7 @@
 //
 //  File:      RuntimeAPISample.swift
 //  Created:   2026-06-14
-//  Updated:   2026-07-02
+//  Updated:   2026-08-16
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Result of an OPT-IN poll of a local AI runtime's HTTP API (Ollama,
 //             llama.cpp server, LM Studio, exo). Carries the loaded model(s), the authoritative
@@ -46,7 +46,7 @@ public struct RuntimeModelInfo: Sendable, Equatable, Identifiable, Codable {
 }
 
 public struct RuntimeAPISample: Sendable, Equatable, Codable {
-    public enum Source: String, Sendable, Equatable, Codable { case ollama, llamaCpp, lmStudio, rapidMLX, exo, omlx }
+    public enum Source: String, Sendable, Equatable, Codable { case ollama, llamaCpp, lmStudio, rapidMLX, mlxDSpark, exo, omlx }
     public enum Status: String, Sendable, Equatable, Codable {
         case disabled            // feature off
         case unreachable         // no runtime / port closed / decode failure / stale (C4)

--- a/Sources/sscope-cli/main.swift
+++ b/Sources/sscope-cli/main.swift
@@ -1,7 +1,7 @@
 //
 //  File:      main.swift
 //  Created:   2026-06-08
-//  Updated:   2026-08-10
+//  Updated:   2026-08-16
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Verification CLI for SiliconScopeCore. Prints sudoless power + CPU samples
 //             so we can confirm the data layer works in a real SwiftPM build.
@@ -93,6 +93,7 @@ if let kind = ai.primaryKind {
 if CommandLine.arguments.contains("--ai") {
     let result = await RuntimeAPIClient().probe(
         primaryKind: ai.primaryKind, ollamaEmbeddedPort: ai.ollamaEmbeddedPort,
+        mlxDSparkEmbeddedPort: ai.mlxDSparkEmbeddedPort,
         ollamaPort: 11434, lmStudioPort: 1234, omlxPort: 8000, omlxApiKey: "")
     let src = result.source.map { " · \($0.rawValue)" } ?? ""
     print("\nruntime API: \(result.status.rawValue)\(src)")
@@ -113,9 +114,10 @@ if CommandLine.arguments.contains("--bench") {
     let kind = ai.primaryKind
     let api = await RuntimeAPIClient().probe(
         primaryKind: kind, ollamaEmbeddedPort: ai.ollamaEmbeddedPort,
+        mlxDSparkEmbeddedPort: ai.mlxDSparkEmbeddedPort,
         ollamaPort: 11434, lmStudioPort: 1234, omlxPort: 8000, omlxApiKey: "")
     if let kind, let model = api.loadedModels.first?.name {
-        let port = switch kind { case .lmStudio: 1234; case .rapidMLX: 8000; case .exo: 52415; case .omlx: 8000; default: 11434 }
+        let port = switch kind { case .lmStudio: 1234; case .rapidMLX: 8000; case .exo: 52415; case .omlx: 8000; case .mlxDSpark: ai.mlxDSparkEmbeddedPort ?? 8080; default: 11434 }
         print("\nbenchmark: \(kind.displayName) · \(model) — generating…")
         if let r = await BenchmarkClient().run(kind: kind, port: port, model: model, apiKey: nil) {
             print(String(format: "  decode: %.1f tok/s  (%d tokens)", r.tokensPerSec, r.tokenCount))

--- a/Tests/SiliconScopeCoreTests/AIRuntimeMatchTests.swift
+++ b/Tests/SiliconScopeCoreTests/AIRuntimeMatchTests.swift
@@ -1,12 +1,13 @@
 //
 //  File:      AIRuntimeMatchTests.swift
 //  Created:   2026-06-14
-//  Updated:   2026-08-08
+//  Updated:   2026-08-16
 //  Developer: Kennt Kim / Calida Lab
 //  Overview:  Adversarial tests for AIRuntimeKind.match — the bundle-first, two-stage
 //             classifier. Locks in the cases that must NOT regress (Ollama runner is not
 //             llama.cpp; generic server/main are not runtimes; empty path never crashes;
-//             the short "exo" substring never false-positives on hexo/Plexos/nexo).
+//             the short "exo" substring never false-positives on hexo/Plexos/nexo; an
+//             mlx-dspark cache/checkout path in an unrelated argv is not mlx-dspark).
 //  Notes:     argv strings are REPRESENTATIVE, not pinned from a live run (the runner's
 //             --port is dynamic). The logic under test is pure (path/name/args -> kind),
 //             so synthetic inputs exercise it deterministically.
@@ -82,6 +83,58 @@ final class AIRuntimeMatchTests: XCTestCase {
         // Must NOT be misclassified as bare MLX even with no argv.
         XCTAssertNotEqual(AIRuntimeKind.match(path: "/Users/x/.local/bin/rapid-mlx",
                                               name: "rapid-mlx", args: nil), .mlx)
+    }
+
+    // mlx-dspark (ARahim3/mlx-dspark) — OpenAI-compatible speculative-decoding server, default
+    // :8080. Its console entry point is a shebang Python file, so macOS reports the interpreter
+    // and `/bin/mlx-dspark` lives in argv (mirrors vLLM/exo) — which is why the positives below
+    // pass `path:` = the python binary.
+    func testMlxDSparkMatch() {
+        // Canonical launch via the console entry point (uv tool / pipx / venv install) — including
+        // a non-default --port, which must surface as the embedded port so the API probe follows
+        // the server instead of knocking on :8080.
+        let uvToolPy = "/Users/x/.local/share/uv/tools/mlx-dspark/bin/python3"
+        let args = "\(uvToolPy) /Users/x/.local/bin/mlx-dspark serve --model mlx-community/Qwen3-8B-8bit " +
+                   "--port 18080 --prefix-cache-dir /Users/x/.cache/mlx-dspark"
+        XCTAssertEqual(AIRuntimeKind.match(path: uvToolPy, name: "python3", args: args), .mlxDSpark)
+        XCTAssertEqual(AIRuntimeKind.embeddedPort(args: args), 18080)
+        // Module invocation via python — argv carries `-m mlx_dspark`.
+        XCTAssertEqual(AIRuntimeKind.match(path: "/opt/homebrew/bin/python3.12", name: "python3.12",
+                                           args: "python -m mlx_dspark serve --model mlx-community/Qwen3-8B-8bit"), .mlxDSpark)
+        // Bare launch (no arguments at all) — the entry point ends the argv, so the
+        // end-of-string half of the trailing bound must still match.
+        XCTAssertEqual(AIRuntimeKind.match(path: "/opt/homebrew/bin/python3.12", name: "python3.12",
+                                           args: "/opt/homebrew/bin/python3.12 /Users/x/.local/bin/mlx-dspark"), .mlxDSpark)
+        // Defensive: a proc table that reports the script itself still resolves with no argv.
+        XCTAssertEqual(AIRuntimeKind.match(path: "/Users/x/.local/bin/mlx-dspark",
+                                           name: "mlx-dspark", args: nil), .mlxDSpark)
+        // Must NOT degrade to bare .mlx.
+        XCTAssertNotEqual(AIRuntimeKind.match(path: uvToolPy, name: "python3", args: args), .mlx)
+    }
+
+    // An `mlx-dspark` SEGMENT in an unrelated argv or path must NOT be treated as the runtime.
+    // The sharpest case is self-inflicted: an mlx-dspark-named folder (its --prefix-cache-dir, a
+    // checkout) shows up in OTHER tools' argv (a backup script, du, tar) — only the
+    // `/bin/mlx-dspark` entry point, its basename, or a `-m mlx_dspark` invocation is
+    // authoritative. Mirrors testVllmDoesNotFalsePositive / #38.
+    func testMlxDSparkDoesNotFalsePositive() {
+        // argv side — another python tool sweeping an mlx-dspark cache dir is not the runtime.
+        XCTAssertNil(AIRuntimeKind.match(path: "/opt/homebrew/bin/python3.12", name: "python3.12",
+                                         args: "python /Users/x/backup.py --src /Users/x/.cache/mlx-dspark"))
+        // argv side — `pip install mlx-dspark` installs the package, it does not serve a model.
+        XCTAssertNil(AIRuntimeKind.match(path: "/opt/homebrew/bin/python3.12", name: "python3.12",
+                                         args: "python -m pip install mlx-dspark"))
+        // PATH side — an `mlx-dspark` source-checkout folder running tests is not the runtime.
+        XCTAssertNil(AIRuntimeKind.match(path: "/Users/me/src/mlx-dspark/.venv/bin/pytest",
+                                         name: "pytest", args: nil))
+        // Trailing bound — a sibling helper script or a same-prefixed package is not the runtime
+        // (the signals require a space or end-of-argv after the entry point / module name).
+        XCTAssertNil(AIRuntimeKind.match(path: "/opt/homebrew/bin/python3.12", name: "python3.12",
+                                         args: "python /Users/x/.venv/bin/mlx-dspark-backup --src /Users/x/data"))
+        XCTAssertNil(AIRuntimeKind.match(path: "/opt/homebrew/bin/python3.12", name: "python3.12",
+                                         args: "python /Users/x/.venv/bin/mlx-dspark.cache --src /Users/x/data"))
+        XCTAssertNil(AIRuntimeKind.match(path: "/opt/homebrew/bin/python3.12", name: "python3.12",
+                                         args: "python -m mlx_dspark_tools clean-cache"))
     }
 
     func testOMLXMatch() {


### PR DESCRIPTION
## What

Adds [mlx-dspark](https://github.com/ARahim3/mlx-dspark) (DSpark/DFlash speculative decoding for Apple Silicon via MLX) as a first-class runtime in the AI Runtime feature:

- **Detection** (`AIRuntimeKind.mlxDSpark`): its console entry point is a shebang Python file, so macOS reports the interpreter and `/bin/mlx-dspark` lives in argv — the same situation vLLM and exo already handle. Signals are the entry-point path in argv, a `-m mlx_dspark` module invocation, and the bare basename as a defensive fallback. Every argv signal is bounded on both sides (leading `/bin/` / `-m `, trailing space-or-end), so an `mlx-dspark` checkout folder, a `--prefix-cache-dir` path in an unrelated process's argv, or a sibling helper script like `mlx-dspark-backup` stays unmatched (the vLLM bound from #38, extended to the trailing side). The arm sits before the generic MLX arm so its processes never degrade to bare `.mlx`.
- **API probe**: it serves an OpenAI-compatible `/v1/models` (default `127.0.0.1:8080`), so it joins the `probeOpenAI` family. The port comes from the process's own `--port` argv when present, falling back to 8080. For the canonical installs (uv tool / pipx / venv) the argv carries the port, so no Settings field is needed.
- **Benchmark**: `benchmarkPort(for:)` and the `sscope-cli --bench` switch route it to the existing OpenAI-compatible benchmark path on the same argv-derived port.
- Menu-bar/dashboard icon: `sparkles` (a speculative decoder's drafter "spark").

## Why

Running `mlx-dspark serve` previously matched nothing in the catalog — the card showed "No local AI runtime detected" while the server was driving the GPU.

## Verification

- `xcrun swift build` and `xcrun swift test` pass (219 tests, including the new match and false-positive suites).
- Verified live on an Apple Silicon Mac against mlx-dspark v0.12.1 serving on a non-default `--port`: the runtime card and `sscope-cli` show `mlx-dspark :<port>`, and `sscope-cli --ai` reports `runtime API: ok · mlxDSpark` with the loaded model id — the run exercised the argv-port path rather than the 8080 default.
- New adversarial tests lock the false-positive bounds: an unrelated python process sweeping an mlx-dspark cache dir, `pip install mlx-dspark`, a source-checkout `.venv`, a sibling `mlx-dspark-backup` helper, and a same-prefixed `-m mlx_dspark_tools` module all stay unmatched.

## Known limitation (out of scope here)

`mlx-dspark serve --api-key KEY` guards its POST routes but answers `GET /v1/models` unauthenticated, so against a keyed server the model card works while the opt-in "Measure tok/s" benchmark gets a 401 and reports its generic failure line. A fix is either an oMLX-style Settings key field or parsing the key out of the server's argv; since `AIRuntimeProcess` is `Codable` into recordings, where a secret must never land, I left that design decision to you. Glad to implement whichever route you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
